### PR TITLE
[Thin BFF #201] feat(bff): Thin BFF 프록시 라우트와 헤더/쿠키 전달 추가

### DIFF
--- a/app/api/bff/[...path]/route.ts
+++ b/app/api/bff/[...path]/route.ts
@@ -1,0 +1,113 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { buildBackendUrl, buildClientResponseHeaders, buildUpstreamRequestHeaders } from "../_lib";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type RouteContext = {
+  params: Promise<{
+    path: string[];
+  }>;
+};
+
+function canHaveBody(method: string) {
+  return method !== "GET" && method !== "HEAD";
+}
+
+async function proxy(req: NextRequest, path: string[]) {
+  const upstreamUrl = buildBackendUrl(req, path);
+  const requestHeaders = buildUpstreamRequestHeaders(req.headers);
+
+  try {
+    const upstreamResponse = await fetch(upstreamUrl, {
+      method: req.method,
+      headers: requestHeaders,
+      body: canHaveBody(req.method) ? await req.arrayBuffer() : undefined,
+      redirect: "manual",
+      signal: req.signal,
+    });
+
+    return new NextResponse(upstreamResponse.body, {
+      status: upstreamResponse.status,
+      headers: buildClientResponseHeaders(upstreamResponse.headers),
+    });
+  } catch (error) {
+    console.error("[bff] upstream request failed", {
+      method: req.method,
+      upstreamUrl,
+      error,
+    });
+
+    return NextResponse.json(
+      {
+        status: "FAIL",
+        code: "UPSTREAM_UNAVAILABLE",
+        message: "일시적으로 서버에 연결할 수 없습니다.",
+      },
+      { status: 502 },
+    );
+  }
+}
+
+async function handle(req: NextRequest, ctx: RouteContext) {
+  const { path } = await ctx.params;
+  return proxy(req, path);
+}
+
+/**
+ * GET 요청용 Route Handler 엔트리.
+ * Next.js가 매칭한 path 파라미터를 공통 프록시 함수로 전달해
+ * 동일한 전달/응답 규칙으로 처리한다.
+ */
+export async function GET(req: NextRequest, ctx: RouteContext) {
+  return handle(req, ctx);
+}
+
+/**
+ * POST 요청용 Route Handler 엔트리.
+ * 로그인/토큰 발급처럼 바디가 필요한 요청도 공통 프록시로 위임한다.
+ */
+export async function POST(req: NextRequest, ctx: RouteContext) {
+  return handle(req, ctx);
+}
+
+/**
+ * PUT 요청용 Route Handler 엔트리.
+ * 토큰 갱신 등 멱등 수정 요청을 공통 프록시 경로로 처리한다.
+ */
+export async function PUT(req: NextRequest, ctx: RouteContext) {
+  return handle(req, ctx);
+}
+
+/**
+ * PATCH 요청용 Route Handler 엔트리.
+ * 부분 수정 API 호출을 별도 로직 없이 공통 프록시로 통합한다.
+ */
+export async function PATCH(req: NextRequest, ctx: RouteContext) {
+  return handle(req, ctx);
+}
+
+/**
+ * DELETE 요청용 Route Handler 엔트리.
+ * 로그아웃/삭제 API 응답의 상태 코드와 헤더를 그대로 전달한다.
+ */
+export async function DELETE(req: NextRequest, ctx: RouteContext) {
+  return handle(req, ctx);
+}
+
+/**
+ * HEAD 요청용 Route Handler 엔트리.
+ * 바디 없이 헤더 기반 확인 요청을 공통 프록시 규칙으로 처리한다.
+ */
+export async function HEAD(req: NextRequest, ctx: RouteContext) {
+  return handle(req, ctx);
+}
+
+/**
+ * OPTIONS 요청용 Route Handler 엔트리.
+ * preflight 또는 메서드 질의 요청을 업스트림에 그대로 전달한다.
+ */
+export async function OPTIONS(req: NextRequest, ctx: RouteContext) {
+  return handle(req, ctx);
+}

--- a/app/api/bff/_lib.ts
+++ b/app/api/bff/_lib.ts
@@ -1,0 +1,101 @@
+import type { NextRequest } from "next/server";
+
+const REQUEST_HEADER_ALLOWLIST = new Set([
+  "accept",
+  "accept-language",
+  "authorization",
+  "content-type",
+  "cookie",
+  "if-match",
+  "if-none-match",
+  "user-agent",
+  "x-correlation-id",
+  "x-request-id",
+]);
+
+const RESPONSE_HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+type HeadersWithGetSetCookie = Headers & {
+  getSetCookie?: () => string[];
+};
+
+function ensureTrailingSlash(url: string) {
+  return url.endsWith("/") ? url : `${url}/`;
+}
+
+/**
+ * 프록시 경로 세그먼트와 원본 쿼리스트링을 기반으로 업스트림 URL을 생성한다.
+ * 모든 환경(local/staging/prod)은 API_PROXY_TARGET만 다르고
+ * 프록시 코드 자체는 동일하게 유지되도록 URL 조합 책임을 이 함수로 고정한다.
+ */
+export function buildBackendUrl(req: NextRequest, path: string[]) {
+  const base = process.env.API_PROXY_TARGET?.trim();
+  if (!base) {
+    throw new Error("API_PROXY_TARGET is required");
+  }
+
+  const upstreamUrl = new URL(path.join("/"), ensureTrailingSlash(base));
+  upstreamUrl.search = req.nextUrl.search;
+  return upstreamUrl.toString();
+}
+
+/**
+ * 브라우저 요청 헤더 중 업스트림 전달이 필요한 항목만 추려서 만든다.
+ * Cookie/Authorization/Content-Type 같은 인증·요청 의미 보존 헤더만 유지하고
+ * 나머지 헤더는 전달하지 않아 프록시 계층의 변동성과 보안 리스크를 줄인다.
+ */
+export function buildUpstreamRequestHeaders(source: Headers) {
+  const headers = new Headers();
+
+  source.forEach((value, key) => {
+    const lowerKey = key.toLowerCase();
+    if (!REQUEST_HEADER_ALLOWLIST.has(lowerKey)) {
+      return;
+    }
+    headers.set(key, value);
+  });
+
+  return headers;
+}
+
+/**
+ * 업스트림 응답 헤더를 브라우저로 재전달 가능한 형태로 변환한다.
+ * hop-by-hop 헤더는 제거하고, Set-Cookie는 단일/복수 케이스를 분기해 append 하여
+ * 리프레시 토큰 쿠키가 손실되지 않도록 보존한다.
+ */
+export function buildClientResponseHeaders(source: Headers) {
+  const headers = new Headers();
+  const sourceHeaders = source as HeadersWithGetSetCookie;
+
+  source.forEach((value, key) => {
+    const lowerKey = key.toLowerCase();
+    if (RESPONSE_HOP_BY_HOP_HEADERS.has(lowerKey) || lowerKey === "set-cookie") {
+      return;
+    }
+    headers.set(key, value);
+  });
+
+  const setCookies =
+    typeof sourceHeaders.getSetCookie === "function" ? sourceHeaders.getSetCookie() : [];
+
+  if (setCookies.length > 0) {
+    setCookies.forEach((cookie) => headers.append("set-cookie", cookie));
+    return headers;
+  }
+
+  const singleCookie = source.get("set-cookie");
+  if (singleCookie) {
+    headers.append("set-cookie", singleCookie);
+  }
+
+  return headers;
+}


### PR DESCRIPTION
## 변경 요약
- Thin BFF 공통 프록시 라우트 핸들러를 추가했습니다.
- 업스트림 요청 헤더 allowlist 전달 규칙을 구현했습니다.
- 업스트림 응답의 `Set-Cookie`를 보존하고 hop-by-hop 헤더는 제거하도록 처리했습니다.

## 변경 파일
- `app/api/bff/[...path]/route.ts`
- `app/api/bff/_lib.ts`

## 검증
- 커밋 훅에서 lint 실행 통과
- 로컬에서 `/api/bff/**` 프록시 경유 응답 확인

## 관련 이슈
- Closes #201

## 참고 문서
- https://github.com/100-hours-a-week/7-team-temporary-fe/wiki/thin-bff-proxy-structure
- https://github.com/100-hours-a-week/7-team-temporary-fe/wiki/thin-bff-cookie-forwarding-troubleshooting
- https://github.com/100-hours-a-week/7-team-temporary-fe/wiki/thin-bff-v2-evidence
- https://github.com/100-hours-a-week/7-team-temporary-fe/wiki/thin-bff-issue-close-mapping
