### PR TITLE
[thin BFF #202] feat(auth): 인증 요청 BFF 경유와 refresh 흐름 단일화

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -4,8 +4,9 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { useEffect, useRef, useState } from "react";
 import { ToastProvider } from "@/shared/ui/toast";
+import { ApiError } from "@/shared/api";
 import { AuthRouteWatcher } from "@/features/auth";
-import { configureAuthHandlers } from "@/shared/auth";
+import { AuthService, configureAuthHandlers } from "@/shared/auth";
 import { useAuthStore } from "@/entities/user";
 import { registerFcmToken } from "@/shared/firebase/registerFcmToken";
 import { registerServiceWorker } from "@/shared/pwa/registerServiceWorker";
@@ -36,11 +37,36 @@ export function Providers({ children }: { children: React.ReactNode }) {
   }, []);
 
   const accessToken = useAuthStore((state) => state.accessToken);
+  const setAuthChecking = useAuthStore((state) => state.setAuthChecking);
   const prevAccessTokenRef = useRef<string | undefined>(accessToken);
 
   useEffect(() => {
     registerServiceWorker();
   }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const bootstrapAuth = async () => {
+      try {
+        await AuthService.refresh();
+      } catch (error) {
+        if (!(error instanceof ApiError && error.httpStatus === 401)) {
+          console.warn("[AuthBootstrap] refresh skipped or failed", error);
+        }
+      } finally {
+        if (!cancelled) {
+          setAuthChecking(false);
+        }
+      }
+    };
+
+    void bootstrapAuth();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [setAuthChecking]);
 
   useEffect(() => {
     const prevAccessToken = prevAccessTokenRef.current;

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,28 +1,18 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-
-const PUBLIC_PATHS = ["/login", "/sign-up"];
-const DEFAULT_PUBLIC_REDIRECT = "/home";
-
-function isPublicPath(pathname: string) {
-  return PUBLIC_PATHS.some((path) => pathname === path || pathname.startsWith(`${path}/`));
-}
+import { AUTH_LOGIN_PATH, isAuthPublicPath } from "@/shared/auth/auth.routes";
 
 export function middleware(request: NextRequest) {
-  if (process.env.NEXT_PUBLIC_ENABLE_MIDDLEWARE !== "true") {
-    return NextResponse.next();
-  }
-
   const { pathname } = request.nextUrl;
   const hasRefreshToken = request.cookies.has("refreshToken");
 
-  if (isPublicPath(pathname) && hasRefreshToken) {
-    return NextResponse.redirect(new URL(DEFAULT_PUBLIC_REDIRECT, request.url));
-  }
-
-  if (!isPublicPath(pathname) && !hasRefreshToken) {
-    return NextResponse.redirect(new URL("/login", request.url));
+  if (!isAuthPublicPath(pathname) && !hasRefreshToken) {
+    return NextResponse.redirect(new URL(AUTH_LOGIN_PATH, request.url));
   }
 
   return NextResponse.next();
 }
+
+export const config = {
+  matcher: ["/((?!api|_next/static|_next/image|favicon.ico|.*\\..*).*)"],
+};

--- a/src/entities/issue/api/issue.api.ts
+++ b/src/entities/issue/api/issue.api.ts
@@ -1,10 +1,13 @@
 import { apiFetch, Endpoint } from "@/shared/api";
+import { AuthService } from "@/shared/auth";
 import type { CreateIssueRequestDto } from "./types";
 
 export async function createIssue(payload: CreateIssueRequestDto): Promise<void> {
-  await apiFetch<void, CreateIssueRequestDto>(Endpoint.ISSUE.BASE, {
-    method: "POST",
-    body: payload,
-    authRequired: true,
-  });
+  await AuthService.refreshAndRetry(() =>
+    apiFetch<void, CreateIssueRequestDto>(Endpoint.ISSUE.BASE, {
+      method: "POST",
+      body: payload,
+      authRequired: true,
+    }),
+  );
 }

--- a/src/entities/user/model/auth.store.ts
+++ b/src/entities/user/model/auth.store.ts
@@ -3,17 +3,22 @@ import { create } from "zustand";
 export interface AuthState {
   accessToken?: string;
   isAuthenticated: boolean;
+  isAuthChecking: boolean;
   suppressPublicRedirect: boolean;
   setAuthenticated: (token: string) => void;
   clearAuth: () => void;
   setSuppressPublicRedirect: (value: boolean) => void;
+  setAuthChecking: (value: boolean) => void;
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
   accessToken: undefined,
   isAuthenticated: false,
+  isAuthChecking: true,
   suppressPublicRedirect: false,
-  setAuthenticated: (token) => set({ accessToken: token, isAuthenticated: true }),
-  clearAuth: () => set({ accessToken: undefined, isAuthenticated: false }),
+  setAuthenticated: (token) =>
+    set({ accessToken: token, isAuthenticated: true, isAuthChecking: false }),
+  clearAuth: () => set({ accessToken: undefined, isAuthenticated: false, isAuthChecking: false }),
   setSuppressPublicRedirect: (value) => set({ suppressPublicRedirect: value }),
+  setAuthChecking: (value) => set({ isAuthChecking: value }),
 }));

--- a/src/features/auth/guard/ui/AuthRouteWatcher.tsx
+++ b/src/features/auth/guard/ui/AuthRouteWatcher.tsx
@@ -1,37 +1,33 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { usePathname, useRouter } from "next/navigation";
 
 import { useAuthStore } from "@/entities/user";
-
-const PUBLIC_PATHS = ["/login", "/sign-up"];
-const DEFAULT_PUBLIC_REDIRECT = "/home";
-
-function isPublicPath(pathname: string) {
-  return PUBLIC_PATHS.some((path) => pathname === path || pathname.startsWith(`${path}/`));
-}
+import { AUTH_DEFAULT_AUTHENTICATED_PATH, AUTH_LOGIN_PATH, isAuthPublicPath } from "@/shared/auth";
 
 export function AuthRouteWatcher() {
   const router = useRouter();
   const pathname = usePathname();
   const accessToken = useAuthStore((state) => state.accessToken);
+  const isAuthChecking = useAuthStore((state) => state.isAuthChecking);
   const suppressPublicRedirect = useAuthStore((state) => state.suppressPublicRedirect);
 
   useEffect(() => {
     if (!pathname) return;
+    if (isAuthChecking) return;
 
-    const isPublic = isPublicPath(pathname);
+    const isPublic = isAuthPublicPath(pathname);
 
     if (!accessToken && !isPublic) {
-      router.replace(PUBLIC_PATHS[0]);
+      router.replace(AUTH_LOGIN_PATH);
       return;
     }
 
     if (accessToken && isPublic && !suppressPublicRedirect) {
-      router.replace(DEFAULT_PUBLIC_REDIRECT);
+      router.replace(AUTH_DEFAULT_AUTHENTICATED_PATH);
     }
-  }, [accessToken, pathname, router, suppressPublicRedirect]);
+  }, [accessToken, isAuthChecking, pathname, router, suppressPublicRedirect]);
 
   return null;
 }

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -2,7 +2,6 @@
 
 import type { UseFormRegisterReturn } from "react-hook-form";
 import { useCallback, useEffect, useRef } from "react";
-import { useRouter } from "next/navigation";
 
 import { FormField, ProfileImageKeyInput } from "@/shared/form/ui";
 import { useStackPage } from "@/widgets/stack";
@@ -11,13 +10,11 @@ import { useProfileImagePresign } from "@/features/image";
 import { ActionButton } from "@/shared/ui/button";
 import { useToast } from "@/shared/ui/toast";
 import { AuthService } from "@/shared/auth";
-import { ApiError } from "@/shared/api";
 
 import { MyInfoStackPage } from "./MyInfoStackPage";
 
 export function ProfilePage() {
   const { push } = useStackPage();
-  const router = useRouter();
   const { data: myProfile, isLoading: isProfileLoading } = useMyProfileQuery();
   const { handleFileSelect, previewUrl, imageKey, isUploading, loadImageViewUrl } =
     useProfileImagePresign();
@@ -76,7 +73,6 @@ export function ProfilePage() {
 
   const handleLogout = async () => {
     await AuthService.logout();
-    // router.replace("/login");
   };
 
   const resolvedPreviewUrl = previewUrl ?? myProfile?.profileImageUrl ?? null;

--- a/src/shared/api/apiFetch.ts
+++ b/src/shared/api/apiFetch.ts
@@ -1,5 +1,5 @@
 import { ApiError } from "./error";
-import { clearAuth, getAccessToken } from "@/shared/auth";
+import { getAccessToken } from "@/shared/auth";
 
 type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
 
@@ -77,24 +77,6 @@ export async function apiFetch<TResponse, TBody = unknown>(
 
   // HTTP 실패
   if (!res.ok) {
-    if (res.status === 401) {
-      clearAuth();
-      const shouldRedirectOnUnauthorized = process.env.NODE_ENV !== "development";
-      if (shouldRedirectOnUnauthorized && typeof window !== "undefined") {
-        const { pathname } = window.location;
-        if (pathname !== "/login") {
-          window.dispatchEvent(
-            new CustomEvent("app:toast", {
-              detail: {
-                message: "로그인이 만료되었습니다. 다시 로그인해 주세요.",
-                type: "error",
-              },
-            }),
-          );
-          window.location.assign("/login");
-        }
-      }
-    }
     const fallbackCode = res.status === 401 ? "UNAUTHORIZED" : "HTTP_ERROR";
     throw new ApiError(
       res.status,

--- a/src/shared/api/endpoints.ts
+++ b/src/shared/api/endpoints.ts
@@ -1,4 +1,7 @@
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
+const configuredApiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL?.trim();
+const API_BASE_URL = (
+  configuredApiBaseUrl && configuredApiBaseUrl.length > 0 ? configuredApiBaseUrl : "/api/bff"
+).replace(/\/$/, "");
 
 /**
  * base url + endpoint path 결합 유틸

--- a/src/shared/auth/auth.routes.ts
+++ b/src/shared/auth/auth.routes.ts
@@ -1,0 +1,7 @@
+export const AUTH_PUBLIC_PATHS = ["/login", "/sign-up"] as const;
+export const AUTH_LOGIN_PATH = AUTH_PUBLIC_PATHS[0];
+export const AUTH_DEFAULT_AUTHENTICATED_PATH = "/home";
+
+export function isAuthPublicPath(pathname: string) {
+  return AUTH_PUBLIC_PATHS.some((path) => pathname === path || pathname.startsWith(`${path}/`));
+}

--- a/src/shared/auth/auth.service.ts
+++ b/src/shared/auth/auth.service.ts
@@ -1,12 +1,25 @@
 import { ApiError, apiFetch, Endpoint } from "@/shared/api";
-import { clearAuth, setAuthenticated } from "./auth.handlers";
+import { clearAuth, getAccessToken, setAuthenticated } from "./auth.handlers";
+
+let refreshPromise: Promise<string> | null = null;
+
+function isUnauthorizedError(error: unknown) {
+  if (error instanceof ApiError) return error.httpStatus === 401;
+  if (typeof error === "object" && error !== null && "httpStatus" in error) {
+    return (error as ApiError).httpStatus === 401;
+  }
+  return false;
+}
 
 export const AuthService = {
-  async refresh() {
+  async refresh(accessTokenSnapshot?: string) {
     try {
       console.log("[AuthService] refresh start");
+      const accessToken = accessTokenSnapshot ?? getAccessToken();
       const res = await apiFetch<{ accessToken: string }>(Endpoint.TOKEN.REFRESH, {
         method: "PUT",
+        credentials: "include",
+        headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : undefined,
       });
 
       setAuthenticated(res.accessToken);
@@ -19,27 +32,36 @@ export const AuthService = {
     }
   },
 
+  async ensureRefreshed(accessTokenSnapshot?: string) {
+    if (!refreshPromise) {
+      refreshPromise = AuthService.refresh(accessTokenSnapshot).finally(() => {
+        refreshPromise = null;
+      });
+    }
+    return refreshPromise;
+  },
+
   async refreshAndRetry<T>(request: () => Promise<T>) {
+    const accessTokenSnapshot = getAccessToken();
     try {
       return await request();
-    } catch (e) {
-      const isUnauthorized =
-        e instanceof ApiError
-          ? e.httpStatus === 401
-          : typeof e === "object" &&
-            e !== null &&
-            "httpStatus" in e &&
-            (e as ApiError).httpStatus === 401;
-
-      if (isUnauthorized) {
-        console.log("[AuthService] 401 detected, try refresh");
-        const refreshed = await AuthService.refresh();
-        if (refreshed) {
-          console.log("[AuthService] retry after refresh");
-          return await request();
-        }
+    } catch (error) {
+      if (!isUnauthorizedError(error)) {
+        throw error;
       }
-      throw e;
+
+      console.log("[AuthService] 401 detected, try refresh");
+      await AuthService.ensureRefreshed(accessTokenSnapshot);
+
+      try {
+        console.log("[AuthService] retry after refresh");
+        return await request();
+      } catch (retryError) {
+        if (isUnauthorizedError(retryError)) {
+          clearAuth();
+        }
+        throw retryError;
+      }
     }
   },
 

--- a/src/shared/auth/index.ts
+++ b/src/shared/auth/index.ts
@@ -5,3 +5,9 @@ export {
   getAccessToken,
   setAuthenticated,
 } from "./auth.handlers";
+export {
+  AUTH_DEFAULT_AUTHENTICATED_PATH,
+  AUTH_LOGIN_PATH,
+  AUTH_PUBLIC_PATHS,
+  isAuthPublicPath,
+} from "./auth.routes";

--- a/src/shared/query/useApiMutation.ts
+++ b/src/shared/query/useApiMutation.ts
@@ -1,7 +1,7 @@
-import { ApiError } from "@/shared/api";
 import { apiFetch } from "@/shared/api";
 import { AuthService } from "@/shared/auth";
 import { mapCommonError } from "@/shared/api/error/common";
+import type { ApiError } from "@/shared/api";
 
 interface UseApiMutationProps<TForm, TDto, TResult = void> {
   url: string | ((form: TForm) => string);
@@ -30,14 +30,15 @@ export function useApiMutation<TForm, TDto, TResult = void>({
   method,
   dtoFn,
   authRequired = false,
-  refreshOnUnauthorized = false,
+  refreshOnUnauthorized,
   onSuccess,
-  onError: handleError,
+  onError: _onError,
   invalidateKeys = [],
   errorMapper,
   credentials,
 }: UseApiMutationProps<TForm, TDto, TResult>) {
   const queryClient = useQueryClient();
+  const shouldRefreshOnUnauthorized = refreshOnUnauthorized ?? authRequired;
 
   return useMutation({
     mutationFn: async (form: TForm) => {
@@ -51,7 +52,7 @@ export function useApiMutation<TForm, TDto, TResult = void>({
             credentials,
             authRequired,
           });
-        if (refreshOnUnauthorized) {
+        if (shouldRefreshOnUnauthorized) {
           return await AuthService.refreshAndRetry(execute);
         }
         return await execute();


### PR DESCRIPTION
## 변경 요약
- 인증 관련 API 기본 경로를 `/api/bff`로 전환했습니다.
- 401 처리/재발급/재시도 책임을 `AuthService`로 단일화했습니다.
- `apiFetch`의 하드코딩 로그인 리다이렉트를 제거했습니다.
- 미들웨어 보호 경로 정책과 인증 경로 상수를 정리했습니다.
- 앱 부트스트랩 시 refresh 1회 수행 + 가드 대기 상태(`isAuthChecking`)를 반영했습니다.

## 변경 파일
- `src/shared/api/endpoints.ts`
- `src/shared/api/apiFetch.ts`
- `src/shared/auth/auth.service.ts`
- `src/shared/auth/index.ts`
- `src/shared/auth/auth.routes.ts`
- `middleware.ts`
- `app/providers.tsx`
- `src/entities/user/model/auth.store.ts`
- `src/features/auth/guard/ui/AuthRouteWatcher.tsx`
- `src/shared/query/useApiMutation.ts`
- `src/entities/issue/api/issue.api.ts`
- `src/pages/profile/ProfilePage.tsx`

## 검증
- `pnpm -s eslint app/providers.tsx middleware.ts src/entities/issue/api/issue.api.ts src/entities/user/model/auth.store.ts src/features/auth/guard/ui/AuthRouteWatcher.tsx src/pages/profile/ProfilePage.tsx src/shared/api/apiFetch.ts src/shared/api/endpoints.ts src/shared/auth/auth.routes.ts src/shared/auth/auth.service.ts src/shared/auth/index.ts src/shared/query/useApiMutation.ts`
- 커밋 훅 lint 실행 통과

## 관련 이슈
- Closes #202

## 참고 문서
- https://github.com/100-hours-a-week/7-team-temporary-fe/wiki/auth-login-refresh-structure
- https://github.com/100-hours-a-week/7-team-temporary-fe/wiki/auth-redirect-control-policy
- https://github.com/100-hours-a-week/7-team-temporary-fe/wiki/thin-bff-v2-evidence
- https://github.com/100-hours-a-week/7-team-temporary-fe/wiki/thin-bff-issue-close-mapping

## 참고 사항
- 이 PR은 `#225` 위에 쌓은 스택 PR입니다.
- base 브랜치: `feat/thin-bff-201`
