### PR TITLE
[구조개선 #174] refactor: PlannerEdit 드래그 상태 초기화 단일화

### DIFF
--- a/src/pages/home/ui/PlannerEditStackPage.tsx
+++ b/src/pages/home/ui/PlannerEditStackPage.tsx
@@ -22,7 +22,6 @@ import {
   ExcludedTaskItem,
   START_HOUR,
   TaskBasketAddSheet,
-  TaskBasketButton,
   TimeSlotGrid,
 } from "@/features/home";
 import {
@@ -45,6 +44,7 @@ import { useToast } from "@/shared/ui/toast";
 import { ExcludedListBottomSheet } from "./ExcludedListBottomSheet";
 import { StackPageEntryContext, useStackPage } from "@/widgets/stack";
 import { TaskBasketStackPage } from "./TaskBasketStackPage";
+import { resetDragState } from "@/widgets/planner-edit";
 
 type DraggedTask = {
   type: "excluded" | "task";
@@ -239,16 +239,16 @@ export function PlannerEditStackPage() {
     }
   }, [isTop, queryClient, scheduleKeys, stack.length]);
 
-  const captureScrollPosition = () => {
+  const captureScrollPosition = useCallback(() => {
     if (!scrollParentRef.current) {
       scrollParentRef.current = getScrollParent(pageRef.current);
     }
     const element = scrollParentRef.current;
     if (!element) return;
     lastScrollTopRef.current = element.scrollTop;
-  };
+  }, []);
 
-  const restoreScrollPosition = () => {
+  const restoreScrollPosition = useCallback(() => {
     if (!scrollParentRef.current) {
       scrollParentRef.current = getScrollParent(pageRef.current);
     }
@@ -258,7 +258,21 @@ export function PlannerEditStackPage() {
     requestAnimationFrame(() => {
       element.scrollTop = scrollTop;
     });
-  };
+  }, []);
+
+  const resetPlannerDragState = useCallback(() => {
+    resetDragState({
+      setActiveDrag,
+      setDraggingType,
+      setPreviewSlot,
+      setInsertPreview,
+      previewKeyRef,
+      insertKeyRef,
+      dragDurationRef,
+      defaultDurationMinutes: DEFAULT_DROP_DURATION_MINUTES,
+      restoreScrollPosition,
+    });
+  }, [restoreScrollPosition]);
 
   const updateScheduleMutation = useMutation({
     mutationFn: async (variables: {
@@ -463,14 +477,7 @@ export function PlannerEditStackPage() {
       | { type?: string; hour?: number; minute?: number }
       | undefined;
     if (!payload) {
-      setActiveDrag(null);
-      setDraggingType(null);
-      setPreviewSlot(null);
-      previewKeyRef.current = null;
-      setInsertPreview(null);
-      insertKeyRef.current = null;
-      dragDurationRef.current = DEFAULT_DROP_DURATION_MINUTES;
-      restoreScrollPosition();
+      resetPlannerDragState();
       return;
     }
     let startAt: string | null = null;
@@ -491,25 +498,13 @@ export function PlannerEditStackPage() {
     }
 
     if (!startAt || !endAt) {
-      setActiveDrag(null);
-      setPreviewSlot(null);
-      previewKeyRef.current = null;
-      setInsertPreview(null);
-      insertKeyRef.current = null;
-      dragDurationRef.current = DEFAULT_DROP_DURATION_MINUTES;
-      restoreScrollPosition();
+      resetPlannerDragState();
       return;
     }
 
     if (isAfterDayEnd(startAt, endAt, dayEndMinutes)) {
       showToast("하루 마무리 시간 이후에는 배정할 수 없습니다.", "error");
-      setActiveDrag(null);
-      setPreviewSlot(null);
-      previewKeyRef.current = null;
-      setInsertPreview(null);
-      insertKeyRef.current = null;
-      dragDurationRef.current = DEFAULT_DROP_DURATION_MINUTES;
-      restoreScrollPosition();
+      resetPlannerDragState();
       return;
     }
 
@@ -523,7 +518,10 @@ export function PlannerEditStackPage() {
       map.set(nextTask.scheduleId, nextTask);
       return Array.from(map.values());
     });
-    if (!dayPlanId) return;
+    if (!dayPlanId) {
+      resetPlannerDragState();
+      return;
+    }
     updateScheduleMutation.mutate({
       scheduleId: payload.task.scheduleId,
       payload: {
@@ -533,14 +531,7 @@ export function PlannerEditStackPage() {
       },
       task: nextTask,
     });
-    setActiveDrag(null);
-    setDraggingType(null);
-    setPreviewSlot(null);
-    previewKeyRef.current = null;
-    setInsertPreview(null);
-    insertKeyRef.current = null;
-    dragDurationRef.current = DEFAULT_DROP_DURATION_MINUTES;
-    restoreScrollPosition();
+    resetPlannerDragState();
   };
 
   const handleDragOver = (event: DragOverEvent) => {
@@ -635,16 +626,7 @@ export function PlannerEditStackPage() {
       }}
       onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}
-      onDragCancel={() => {
-        setActiveDrag(null);
-        setDraggingType(null);
-        setPreviewSlot(null);
-        previewKeyRef.current = null;
-        setInsertPreview(null);
-        insertKeyRef.current = null;
-        dragDurationRef.current = DEFAULT_DROP_DURATION_MINUTES;
-        restoreScrollPosition();
-      }}
+      onDragCancel={resetPlannerDragState}
     >
       <>
         <div

--- a/src/widgets/planner-edit/index.ts
+++ b/src/widgets/planner-edit/index.ts
@@ -1,0 +1,1 @@
+export { resetDragState } from "./lib/resetDragState";

--- a/src/widgets/planner-edit/lib/resetDragState.ts
+++ b/src/widgets/planner-edit/lib/resetDragState.ts
@@ -1,0 +1,35 @@
+type ResetStateSetter<T> = (value: T | null) => void;
+type RefObject<T> = { current: T };
+
+type ResetDragStateParams<ActiveDrag, DraggingType, PreviewSlot, InsertPreview> = {
+  setActiveDrag: ResetStateSetter<ActiveDrag>;
+  setDraggingType: ResetStateSetter<DraggingType>;
+  setPreviewSlot: ResetStateSetter<PreviewSlot>;
+  setInsertPreview: ResetStateSetter<InsertPreview>;
+  previewKeyRef: RefObject<string | null>;
+  insertKeyRef: RefObject<string | null>;
+  dragDurationRef: RefObject<number>;
+  defaultDurationMinutes: number;
+  restoreScrollPosition: () => void;
+};
+
+export function resetDragState<ActiveDrag, DraggingType, PreviewSlot, InsertPreview>({
+  setActiveDrag,
+  setDraggingType,
+  setPreviewSlot,
+  setInsertPreview,
+  previewKeyRef,
+  insertKeyRef,
+  dragDurationRef,
+  defaultDurationMinutes,
+  restoreScrollPosition,
+}: ResetDragStateParams<ActiveDrag, DraggingType, PreviewSlot, InsertPreview>) {
+  setActiveDrag(null);
+  setDraggingType(null);
+  setPreviewSlot(null);
+  previewKeyRef.current = null;
+  setInsertPreview(null);
+  insertKeyRef.current = null;
+  dragDurationRef.current = defaultDurationMinutes;
+  restoreScrollPosition();
+}


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- PlannerEdit 드래그 종료/취소/실패 분기에 흩어져 있던 상태 초기화 로직을 `resetDragState` 유틸로 단일화했습니다.
- `onDragEnd`, `onDragCancel`, `dayPlanId` early return에서 동일한 리셋 함수를 사용하도록 정리했습니다.
- 스크롤 복원 로직을 포함해 드래그 관련 리셋 경로를 일관화했습니다.

## 작업 배경/목적

- 중복된 드래그 상태 초기화 코드로 인해 분기별 누락/불일치 가능성이 있어, 공통 함수로 표준화해 유지보수성과 안정성을 높이기 위함입니다.

## 영향 범위

- `src/pages/home/ui/PlannerEditStackPage.tsx`
- `src/widgets/planner-edit/lib/resetDragState.ts`
- `src/widgets/planner-edit/index.ts`

## 테스트/검증

- `pnpm exec eslint src/pages/home/ui/PlannerEditStackPage.tsx src/widgets/planner-edit/index.ts src/widgets/planner-edit/lib/resetDragState.ts`
- `pnpm exec tsc --noEmit`

## 관련 이슈

- Closes #174

## 참고 문서/링크

- 이슈: https://github.com/100-hours-a-week/7-team-temporary-fe/issues/174
