### PR TITLE
[retro-main #210] feat: 회고 작성 폼 유효성 검증 및 업로드 조건 구현

### DIFF
--- a/src/features/retro/model/index.ts
+++ b/src/features/retro/model/index.ts
@@ -1,6 +1,14 @@
 export { retroCreateFormSchema } from "./schema";
-export type { RetroCreateFormModel, RetroCreateRequestDto } from "./types";
+export type { RetroCreateFormModel, RetroCreateRequestDto, UploadedRetroImage } from "./types";
 export { toRetroCreateRequestDto } from "./dto";
 export { RETRO_CREATE_FORM_DEFAULTS, useRetroCreateForm } from "./useRetroCreateForm";
 export { useRetroCreateMutation } from "./useRetroCreateMutation";
 export { useRetroSection } from "./useRetroSection";
+export { useRetroWriteImageUpload } from "./useRetroWriteImageUpload";
+export {
+  RETRO_IMAGE_MIN_COUNT,
+  RETRO_IMAGE_MAX_COUNT,
+  RETRO_CONTENT_MAX_LENGTH,
+  RETRO_IMAGE_MAX_TOAST_MESSAGE,
+  RETRO_CONTENT_MAX_HELPER_TEXT,
+} from "./retroWrite.constants";

--- a/src/features/retro/model/retroWrite.constants.ts
+++ b/src/features/retro/model/retroWrite.constants.ts
@@ -1,0 +1,6 @@
+export const RETRO_IMAGE_MIN_COUNT = 1;
+export const RETRO_IMAGE_MAX_COUNT = 10;
+export const RETRO_CONTENT_MAX_LENGTH = 200;
+
+export const RETRO_IMAGE_MAX_TOAST_MESSAGE = "이미지는 최대 10장까지 업로드 가능합니다.";
+export const RETRO_CONTENT_MAX_HELPER_TEXT = "내용은 최대 200자까지 입력할 수 있습니다.";

--- a/src/features/retro/model/schema.ts
+++ b/src/features/retro/model/schema.ts
@@ -2,10 +2,20 @@ import { z } from "zod";
 
 import { RETRO_VISIBILITY } from "@/entities/retro";
 
+import {
+  RETRO_CONTENT_MAX_HELPER_TEXT,
+  RETRO_CONTENT_MAX_LENGTH,
+  RETRO_IMAGE_MAX_COUNT,
+  RETRO_IMAGE_MIN_COUNT,
+} from "./retroWrite.constants";
 import type { RetroCreateFormModel } from "./types";
 
 export const retroCreateFormSchema: z.ZodType<RetroCreateFormModel> = z.object({
-  reflectionImageIds: z.array(z.number().int().positive()),
-  content: z.string(),
+  reflectionImageIds: z.array(z.number().int().positive()).max(RETRO_IMAGE_MAX_COUNT),
+  uploadedImageKeys: z
+    .array(z.string().min(1))
+    .min(RETRO_IMAGE_MIN_COUNT)
+    .max(RETRO_IMAGE_MAX_COUNT),
+  content: z.string().max(RETRO_CONTENT_MAX_LENGTH, RETRO_CONTENT_MAX_HELPER_TEXT),
   visibility: z.enum([RETRO_VISIBILITY.PUBLIC, RETRO_VISIBILITY.PRIVATE]),
 });

--- a/src/features/retro/model/types.ts
+++ b/src/features/retro/model/types.ts
@@ -2,6 +2,7 @@ import type { RetroVisibility } from "@/entities/retro";
 
 export interface RetroCreateFormModel {
   reflectionImageIds: number[];
+  uploadedImageKeys: string[];
   content: string;
   visibility: RetroVisibility;
 }
@@ -9,4 +10,9 @@ export interface RetroCreateFormModel {
 export interface RetroCreateRequestDto {
   reflectionImageIds: number[];
   content: string;
+}
+
+export interface UploadedRetroImage {
+  imageKey: string;
+  viewUrl: string;
 }

--- a/src/features/retro/model/useRetroCreateForm.ts
+++ b/src/features/retro/model/useRetroCreateForm.ts
@@ -11,6 +11,7 @@ import type { RetroCreateFormModel } from "./types";
 
 export const RETRO_CREATE_FORM_DEFAULTS: RetroCreateFormModel = {
   reflectionImageIds: [],
+  uploadedImageKeys: [],
   content: "",
   visibility: RETRO_VISIBILITY.PUBLIC,
 };

--- a/src/features/retro/model/useRetroWriteImageUpload.ts
+++ b/src/features/retro/model/useRetroWriteImageUpload.ts
@@ -1,0 +1,73 @@
+"use client";
+
+import { useCallback, useState, type ChangeEvent } from "react";
+
+import { uploadImageAndResolveViewUrl } from "@/shared/api";
+
+import { RETRO_IMAGE_MAX_COUNT, RETRO_IMAGE_MAX_TOAST_MESSAGE } from "./retroWrite.constants";
+import type { UploadedRetroImage } from "./types";
+
+type ShowToast = (message: string, type?: "info" | "success" | "error") => void;
+
+interface UseRetroWriteImageUploadOptions {
+  showToast: ShowToast;
+}
+
+export function useRetroWriteImageUpload({ showToast }: UseRetroWriteImageUploadOptions) {
+  const [uploadedImages, setUploadedImages] = useState<UploadedRetroImage[]>([]);
+  const [isImageUploading, setIsImageUploading] = useState(false);
+
+  const handleImageChange = useCallback(
+    async (event: ChangeEvent<HTMLInputElement>) => {
+      const files = Array.from(event.target.files ?? []);
+      if (files.length === 0) return;
+
+      const remainingSlots = RETRO_IMAGE_MAX_COUNT - uploadedImages.length;
+
+      if (remainingSlots <= 0) {
+        showToast(RETRO_IMAGE_MAX_TOAST_MESSAGE, "error");
+        event.target.value = "";
+        return;
+      }
+
+      const uploadCandidates = files.slice(0, remainingSlots);
+      if (files.length > uploadCandidates.length) {
+        showToast(RETRO_IMAGE_MAX_TOAST_MESSAGE, "error");
+      }
+
+      setIsImageUploading(true);
+
+      try {
+        const uploadResults = await Promise.allSettled(
+          uploadCandidates.map((file) => uploadImageAndResolveViewUrl(file, "REFLECTIONS")),
+        );
+
+        const uploaded = uploadResults
+          .filter(
+            (result): result is PromiseFulfilledResult<UploadedRetroImage> =>
+              result.status === "fulfilled",
+          )
+          .map((result) => result.value);
+
+        if (uploaded.length > 0) {
+          setUploadedImages((prev) => [...prev, ...uploaded]);
+        }
+
+        const failedCount = uploadResults.length - uploaded.length;
+        if (failedCount > 0) {
+          showToast(`이미지 ${failedCount}개 업로드에 실패했습니다.`, "error");
+        }
+      } finally {
+        setIsImageUploading(false);
+        event.target.value = "";
+      }
+    },
+    [showToast, uploadedImages.length],
+  );
+
+  return {
+    uploadedImages,
+    isImageUploading,
+    handleImageChange,
+  };
+}

--- a/src/features/retro/ui/RetroWriteForm.tsx
+++ b/src/features/retro/ui/RetroWriteForm.tsx
@@ -1,16 +1,21 @@
 "use client";
 
-import { useState, type ChangeEvent } from "react";
+import { useEffect, useState, type ChangeEvent } from "react";
 
 import { RETRO_VISIBILITY, type RetroVisibility } from "@/entities/retro";
-import { uploadImageAndResolveViewUrl } from "@/shared/api";
 import { FixedActionBar, PrimaryButton } from "@/shared/ui/button";
 import { HorizontalImageAlbum } from "@/shared/ui/image";
 import { RetroContentField, RetroVisibilityToggle } from "@/shared/ui/retro";
 import { useToast } from "@/shared/ui/toast";
 import { useMutationErrorEffect } from "@/shared/query";
 
-import { useRetroCreateForm, useRetroCreateMutation } from "../model";
+import {
+  RETRO_CONTENT_MAX_HELPER_TEXT,
+  RETRO_CONTENT_MAX_LENGTH,
+  useRetroCreateForm,
+  useRetroCreateMutation,
+  useRetroWriteImageUpload,
+} from "../model";
 
 interface RetroWriteFormProps {
   dateLabel: string;
@@ -18,63 +23,73 @@ interface RetroWriteFormProps {
 
 export function RetroWriteForm({ dateLabel }: RetroWriteFormProps) {
   const { showToast } = useToast();
-  const [previewUrls, setPreviewUrls] = useState<string[]>([]);
-  const [isImageUploading, setIsImageUploading] = useState(false);
+  const [isContentOverflow, setIsContentOverflow] = useState(false);
+
+  const form = useRetroCreateForm();
+  const {
+    register,
+    watch,
+    setValue,
+    canSubmit,
+    handleSubmit,
+    formState: { errors },
+  } = form;
+
   const createRetroMutation = useRetroCreateMutation({
     onSuccess: () => {
       showToast("회고가 생성되었습니다.", "success");
+      setValue("content", "", { shouldValidate: true });
+      setIsContentOverflow(false);
     },
   });
   useMutationErrorEffect(createRetroMutation);
 
-  const form = useRetroCreateForm({
-    onValid: (values) => {
-      createRetroMutation.mutate(values);
-    },
+  const { uploadedImages, isImageUploading, handleImageChange } = useRetroWriteImageUpload({
+    showToast,
   });
-  const { register, watch, setValue, submitForm, canSubmit } = form;
 
   const visibility = watch("visibility") as RetroVisibility;
-  const content = watch("content");
-  const reflectionImageIds = watch("reflectionImageIds");
+  const content = watch("content") ?? "";
   const isPublic = visibility === RETRO_VISIBILITY.PUBLIC;
-  const hasPayload =
-    content.trim().length > 0 || reflectionImageIds.length > 0 || previewUrls.length > 0;
+  const previewUrls = uploadedImages.map((image) => image.viewUrl);
+  const isUploadDisabled = !canSubmit || isImageUploading || createRetroMutation.isPending;
 
-  const handleImageChange = async (event: ChangeEvent<HTMLInputElement>) => {
-    const files = Array.from(event.target.files ?? []);
-    if (files.length === 0) return;
+  useEffect(() => {
+    setValue(
+      "uploadedImageKeys",
+      uploadedImages.map((image) => image.imageKey),
+      { shouldValidate: true },
+    );
+  }, [uploadedImages, setValue]);
 
-    setIsImageUploading(true);
+  const contentField = register("content");
 
-    try {
-      const uploadResults = await Promise.allSettled(
-        files.map((file) => uploadImageAndResolveViewUrl(file, "REFLECTIONS")),
-      );
+  const handleContentChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    const nextValue = event.target.value;
 
-      const uploaded = uploadResults
-        .filter(
-          (result): result is PromiseFulfilledResult<{ imageKey: string; viewUrl: string }> =>
-            result.status === "fulfilled",
-        )
-        .map((result) => result.value);
-
-      if (uploaded.length > 0) {
-        setPreviewUrls((prev) => [...prev, ...uploaded.map((item) => item.viewUrl)]);
-      }
-
-      // TODO: 이미지 업로드 응답 스펙 확정 후 imageKey -> reflectionImageId 매핑 반영
-      setValue("reflectionImageIds", [], { shouldValidate: true, shouldDirty: true });
-
-      const failedCount = uploadResults.length - uploaded.length;
-      if (failedCount > 0) {
-        showToast(`이미지 ${failedCount}개 업로드에 실패했습니다.`, "error");
-      }
-    } finally {
-      setIsImageUploading(false);
-      event.target.value = "";
+    if (nextValue.length > RETRO_CONTENT_MAX_LENGTH) {
+      setIsContentOverflow(true);
+      setValue("content", nextValue.slice(0, RETRO_CONTENT_MAX_LENGTH), {
+        shouldValidate: true,
+        shouldDirty: true,
+      });
+      return;
     }
+
+    if (isContentOverflow) {
+      setIsContentOverflow(false);
+    }
+
+    setValue("content", nextValue, { shouldValidate: true, shouldDirty: true });
   };
+
+  const handleSubmitRetro = handleSubmit(async (values) => {
+    await createRetroMutation.mutateAsync(values);
+  });
+
+  const contentHelperText = isContentOverflow
+    ? RETRO_CONTENT_MAX_HELPER_TEXT
+    : (errors.content?.message ?? undefined);
 
   return (
     <>
@@ -109,7 +124,12 @@ export function RetroWriteForm({ dateLabel }: RetroWriteFormProps) {
         <RetroContentField
           placeholder="(선택) 내용을 입력하세요."
           className="mt-6"
-          {...register("content")}
+          value={content}
+          name={contentField.name}
+          onBlur={contentField.onBlur}
+          onChange={handleContentChange}
+          invalid={isContentOverflow || Boolean(errors.content)}
+          helperText={contentHelperText}
         />
 
         <div className="mt-5 flex items-center">
@@ -128,8 +148,8 @@ export function RetroWriteForm({ dateLabel }: RetroWriteFormProps) {
       <FixedActionBar>
         <PrimaryButton
           type="button"
-          onClick={() => void submitForm()}
-          disabled={!hasPayload || !canSubmit || isImageUploading || createRetroMutation.isPending}
+          onClick={() => void handleSubmitRetro()}
+          disabled={isUploadDisabled}
         >
           {createRetroMutation.isPending ? "업로드 중..." : "업로드"}
         </PrimaryButton>

--- a/src/shared/ui/retro/RetroContentField.tsx
+++ b/src/shared/ui/retro/RetroContentField.tsx
@@ -4,23 +4,46 @@ import type { TextareaHTMLAttributes } from "react";
 
 import { cn } from "@/shared/lib";
 
-type RetroContentFieldProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
+interface RetroContentFieldProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  invalid?: boolean;
+  helperText?: string;
+  textareaClassName?: string;
+}
 
 const BASE_CLASS_NAME =
   "w-full rounded-2xl border border-[#d8d8d8] bg-[#f7f7f7] text-sm text-black placeholder:text-sm px-3 py-2 placeholder:text-[#bdbdbd]";
 
 export function RetroContentField({
   className,
+  textareaClassName,
+  invalid,
+  helperText,
   value,
   defaultValue,
   ...props
 }: RetroContentFieldProps) {
   return (
-    <textarea
-      className={cn(BASE_CLASS_NAME, "h-[178px] resize-none outline-none", className)}
-      value={value}
-      defaultValue={defaultValue}
-      {...props}
-    />
+    <div className={cn("w-full", className)}>
+      <textarea
+        className={cn(
+          BASE_CLASS_NAME,
+          "h-[178px] resize-none outline-none",
+          invalid ? "border-[var(--color-red-400)]" : null,
+          textareaClassName,
+        )}
+        data-invalid={invalid || undefined}
+        aria-invalid={invalid || undefined}
+        value={value}
+        defaultValue={defaultValue}
+        {...props}
+      />
+      {helperText ? (
+        <p
+          className={cn("mt-1 text-xs", invalid ? "text-[var(--color-red-400)]" : "text-gray-500")}
+        >
+          {helperText}
+        </p>
+      ) : null}
+    </div>
   );
 }


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- 회고 작성 폼 입력 검증을 schema 중심으로 재정렬했습니다.
- 이미지 업로드 정책(최소 1장, 최대 10장, 초과 토스트)을 상수/전용 훅으로 분리했습니다.
- 내용 입력 200자 제한 및 Helper Text 표시를 폼/입력 컴포넌트에 반영했습니다.
- 업로드 버튼 활성 조건을 RHF 유효성(`canSubmit`) 기반으로 정리했습니다.

## 작업 배경/목적

- Auth 도메인과 동일하게 FormModel -> Schema -> Mutation 흐름을 맞추기 위해 검증 책임을 UI에서 schema로 이동했습니다.
- 회고 작성 폼의 검증/상태 로직 응집도를 높이고 예측 가능성을 확보했습니다.

## 영향 범위

- `src/features/retro/model/*`
- `src/features/retro/ui/RetroWriteForm.tsx`
- `src/shared/ui/retro/RetroContentField.tsx`

## 테스트/검증

- `pnpm lint` 통과 (경고만 존재)
- `pnpm build` 통과 (경고만 존재)
- #210 체크리스트 전 항목 [x] 반영 완료

## 관련 이슈

- Closes #210

## 참고 문서/링크

- https://github.com/100-hours-a-week/7-team-temporary-fe/issues/210
