### PR TITLE
[planner #189] refactor: 플래너 무한 스크롤 관찰 로직을 공통 훅으로 통합

### DIFF
--- a/src/features/home/model/useHomePlanner.ts
+++ b/src/features/home/model/useHomePlanner.ts
@@ -1,10 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { RefObject } from "react";
 import {
   toTaskItemModelFromHomeTask,
   type TaskItemModel,
   useHomePlanStore,
 } from "@/entities/day-plan";
+import { useInfiniteScrollTrigger } from "@/shared/hooks";
 import { useHomePlannerCalendar } from "./useHomePlannerCalendar";
 import { useHomePlannerQueries } from "./useHomePlannerQueries";
 import { useMergedTasks } from "./useMergedTasks";
@@ -18,30 +19,6 @@ const formatDateParam = (date: Date) => {
   const day = String(date.getDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
 };
-
-function getScrollParent(element: HTMLElement | null) {
-  if (!element || typeof window === "undefined") return null;
-  const classRoot = element.closest(
-    ".overflow-y-auto, .overflow-auto, .overflow-y-scroll",
-  ) as HTMLElement | null;
-  if (classRoot) return classRoot;
-  let current: HTMLElement | null = element.parentElement;
-  while (current) {
-    const styles = window.getComputedStyle(current);
-    const overflowY = styles.overflowY;
-    const overflow = styles.overflow;
-    if (
-      overflowY === "auto" ||
-      overflowY === "scroll" ||
-      overflow === "auto" ||
-      overflow === "scroll"
-    ) {
-      return current;
-    }
-    current = current.parentElement;
-  }
-  return null;
-}
 
 interface UseHomePlannerResult {
   today: Date;
@@ -70,7 +47,6 @@ export function useHomePlanner(): UseHomePlannerResult {
     () => new Map(),
   );
   const [currentPage, setCurrentPage] = useState(1);
-  const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
   const queryDate = useMemo(() => formatDateParam(selectedDate ?? today), [selectedDate, today]);
   const weekStartDate = useMemo(() => formatDateParam(weekDays[0]), [weekDays]);
@@ -157,24 +133,11 @@ export function useHomePlanner(): UseHomePlannerResult {
     }
   }, [data?.dayPlanId, queryDate, setHomePlan]);
 
-  useEffect(() => {
-    if (!loadMoreRef.current) return;
-    if (!hasMore) return;
-    if (isLoading) return;
-
-    const root = getScrollParent(loadMoreRef.current);
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const isIntersecting = entries.some((entry) => entry.isIntersecting);
-        if (!isIntersecting) return;
-        setCurrentPage((prev) => prev + 1);
-      },
-      { root, rootMargin: "200px" },
-    );
-
-    observer.observe(loadMoreRef.current);
-    return () => observer.disconnect();
-  }, [hasMore, isLoading]);
+  const { loadMoreRef } = useInfiniteScrollTrigger<HTMLDivElement>({
+    hasMore,
+    isFetching: isLoading,
+    onLoadMore: () => setCurrentPage((prev) => prev + 1),
+  });
 
   return {
     today,

--- a/src/widgets/planner-edit/ui/TodoList.tsx
+++ b/src/widgets/planner-edit/ui/TodoList.tsx
@@ -1,12 +1,13 @@
 import styled from "@emotion/styled";
 
 import type { RefObject } from "react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import type { DayPlanScheduleStatus } from "@/entities/day-plan";
 import type { TodoCartTaskItemModel } from "@/entities/day-plan";
 import { useDayPlanScheduleByIdQuery } from "@/entities/day-plan";
 import { TodoCartTaskItem, type TodoCartViewMode } from "@/entities/day-plan";
+import { useInfiniteScrollTrigger } from "@/shared/hooks";
 
 type TodoListTask = TodoCartTaskItemModel & { status?: DayPlanScheduleStatus };
 
@@ -38,7 +39,6 @@ export function TodoList({
   const [currentPage, setCurrentPage] = useState(page);
   const [fetchedTasks, setFetchedTasks] = useState<TodoListTask[]>([]);
   const [totalPages, setTotalPages] = useState<number | null>(null);
-  const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
   const scheduleQuery = useDayPlanScheduleByIdQuery({
     dayPlanId: dayPlanId ?? 0,
@@ -74,7 +74,6 @@ export function TodoList({
 
   useEffect(() => {
     if (!scheduleQuery.data) return;
-    console.log("[TodoList] 일정 조회 응답", scheduleQuery.data);
     setTotalPages(scheduleQuery.data.totalPages);
     setFetchedTasks((prev) => {
       const base = currentPage === 1 ? [] : prev;
@@ -86,25 +85,13 @@ export function TodoList({
 
   const hasMore = totalPages === null ? mappedTasks.length === size : currentPage < totalPages;
 
-  useEffect(() => {
-    if (!shouldFetch) return;
-    if (!loadMoreRef.current) return;
-    if (!hasMore) return;
-    if (scheduleQuery.isFetching) return;
-
-    const root = scrollRootRef?.current ?? getScrollParent(loadMoreRef.current);
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const isIntersecting = entries.some((entry) => entry.isIntersecting);
-        if (!isIntersecting) return;
-        setCurrentPage((prev) => prev + 1);
-      },
-      { root, rootMargin: "200px" },
-    );
-
-    observer.observe(loadMoreRef.current);
-    return () => observer.disconnect();
-  }, [hasMore, scheduleQuery.isFetching, scrollRootRef, shouldFetch]);
+  const { loadMoreRef } = useInfiniteScrollTrigger<HTMLDivElement>({
+    enabled: shouldFetch,
+    hasMore,
+    isFetching: scheduleQuery.isFetching,
+    onLoadMore: () => setCurrentPage((prev) => prev + 1),
+    rootRef: scrollRootRef,
+  });
 
   const mergedTasks = useMemo(() => {
     if (!shouldFetch) return tasks;
@@ -167,30 +154,6 @@ function toMinutes(time?: string) {
   const [hours, minutes] = time.split(":").map(Number);
   if (Number.isNaN(hours) || Number.isNaN(minutes)) return null;
   return hours * 60 + minutes;
-}
-
-function getScrollParent(element: HTMLElement | null) {
-  if (!element || typeof window === "undefined") return null;
-  const classRoot = element.closest(
-    ".overflow-y-auto, .overflow-auto, .overflow-y-scroll",
-  ) as HTMLElement | null;
-  if (classRoot) return classRoot;
-  let current: HTMLElement | null = element.parentElement;
-  while (current) {
-    const styles = window.getComputedStyle(current);
-    const overflowY = styles.overflowY;
-    const overflow = styles.overflow;
-    if (
-      overflowY === "auto" ||
-      overflowY === "scroll" ||
-      overflow === "auto" ||
-      overflow === "scroll"
-    ) {
-      return current;
-    }
-    current = current.parentElement;
-  }
-  return null;
 }
 
 const ListContainer = styled.div`


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- `useHomePlanner`의 로컬 `IntersectionObserver` 구현을 공통 훅(`useInfiniteScrollTrigger`) 사용으로 전환
- `TodoList`의 로컬 `IntersectionObserver` 구현을 공통 훅 사용으로 전환
- `TodoList` 내 디버그 로그 제거

## 작업 배경/목적

- 플래너 영역의 무한 스크롤 관찰 로직이 파일마다 중복되어 있어 유지보수 비용이 증가하는 문제를 줄이기 위함

## 영향 범위

- `src/features/home/model/useHomePlanner.ts`
- `src/widgets/planner-edit/ui/TodoList.tsx`

## 테스트/검증

- pre-commit `next lint` 실행(에러 없음, 기존 경고만 존재)
- 로컬 수동 검증 포인트
  - 홈 플래너 목록 하단 도달 시 추가 페이지 로드
  - PlannerEdit TodoList 하단 도달 시 추가 페이지 로드
  - 기존 스크롤 루트(`scrollRootRef`) 동작 유지

## 관련 이슈

- Refs #189

## 참고 문서/링크

- 이슈: https://github.com/100-hours-a-week/7-team-temporary-fe/issues/189
