### PR TITLE
[friend-list #253] feat: FRIEND_LIST 빈 상태 문구 반영

### DIFF
--- a/src/widgets/friend-list/ui/FriendList.tsx
+++ b/src/widgets/friend-list/ui/FriendList.tsx
@@ -30,7 +30,7 @@ export function FriendList() {
       ) : null}
 
       {!isLoading && !isError && friends.length === 0 ? (
-        <EmptyStateCard message="아직 등록된 친구가 없습니다." />
+        <EmptyStateCard message="아직 친구 목록이 비어 있어요. 새 친구를 만들어볼까요?" />
       ) : null}
 
       {!isLoading && !isError ? (


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- FRIEND_LIST 빈 상태 문구를 요구 문구로 변경했습니다.
  - 변경 전: `아직 등록된 친구가 없습니다.`
  - 변경 후: `아직 친구 목록이 비어 있어요 새 친구를 만들어볼까요?`

## 작업 배경/목적

- #253 이슈의 빈 상태 문구 요구사항을 반영해 정의서와 UI 문구를 일치시키기 위함입니다.

## 영향 범위

- `src/widgets/friend-list/ui/FriendList.tsx`

## 테스트/검증

- 커밋 훅 `next lint` 통과 (기존 프로젝트 warning만 존재)
- 수동 확인: 친구 목록 empty 상태 진입 시 문구 노출 확인

## 관련 이슈

- Closes #253

## 참고 문서/링크

- 이슈: https://github.com/100-hours-a-week/7-team-temporary-fe/issues/253
