### PR TITLE
[fe #282] fix: 비활성 탭 선요청 차단을 위한 언마운트/쿼리 가드 적용

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -87,6 +87,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
     if (typeof window === "undefined") return;
     if (!("Notification" in window)) return;
     if (Notification.permission !== "granted") return;
+    // FCM 토큰 등록은 AppShell 탭 마운트 정책과 분리된 전역 세션 정책으로 유지한다.
 
     let cancelled = false;
     const run = async () => {

--- a/src/features/home/model/useHomePlanner.ts
+++ b/src/features/home/model/useHomePlanner.ts
@@ -40,7 +40,13 @@ interface UseHomePlannerResult {
   loadMoreRef: RefObject<HTMLDivElement | null>;
 }
 
-export function useHomePlanner(): UseHomePlannerResult {
+interface UseHomePlannerOptions {
+  enabled?: boolean;
+}
+
+export function useHomePlanner({
+  enabled = true,
+}: UseHomePlannerOptions = {}): UseHomePlannerResult {
   const { today, weekDays, headerMonthIndex, selectedDate, setSelectedDate, handleMoveWeek } =
     useHomePlannerCalendar();
   const [completionOverrides, setCompletionOverrides] = useState<Map<number, boolean>>(
@@ -65,6 +71,7 @@ export function useHomePlanner(): UseHomePlannerResult {
     pageSize: PAGE_SIZE,
     weekStartDate,
     weekEndDate,
+    enabled,
   });
   const setHomePlan = useHomePlanStore((state) => state.setHomePlan);
 
@@ -134,6 +141,7 @@ export function useHomePlanner(): UseHomePlannerResult {
   }, [data?.dayPlanId, queryDate, setHomePlan]);
 
   const { loadMoreRef } = useInfiniteScrollTrigger<HTMLDivElement>({
+    enabled,
     hasMore,
     isFetching: isLoading,
     onLoadMore: () => setCurrentPage((prev) => prev + 1),

--- a/src/features/home/model/useHomePlannerQueries.ts
+++ b/src/features/home/model/useHomePlannerQueries.ts
@@ -10,6 +10,7 @@ interface UseHomePlannerQueriesParams {
   pageSize: number;
   weekStartDate: string;
   weekEndDate: string;
+  enabled?: boolean;
 }
 
 interface UseHomePlannerQueriesResult {
@@ -38,19 +39,22 @@ export function useHomePlannerQueries({
   pageSize,
   weekStartDate,
   weekEndDate,
+  enabled = true,
 }: UseHomePlannerQueriesParams): UseHomePlannerQueriesResult {
   const { data, isLoading, isError } = useDayPlanScheduleQuery({
     date: queryDate,
     page: currentPage,
     size: pageSize,
+    enabled,
   });
 
   const periodSchedulesQuery = useDayPlanPeriodSchedulesQuery({
     startDate: weekStartDate,
     endDate: weekEndDate,
+    enabled,
   });
 
-  const currentScheduleQuery = useCurrentScheduleQuery();
+  const currentScheduleQuery = useCurrentScheduleQuery({ enabled });
 
   return {
     data,

--- a/src/features/retro/model/useRetroSection.ts
+++ b/src/features/retro/model/useRetroSection.ts
@@ -14,6 +14,10 @@ import {
 const RETRO_LIST_PAGE = 1;
 const RETRO_LIST_SIZE = 10;
 
+interface UseRetroSectionOptions {
+  enabled?: boolean;
+}
+
 /**
  * 회고 피드 탭 상태와 MY_PAGE 목록 페이징을 함께 관리하는 훅.
  *
@@ -21,7 +25,10 @@ const RETRO_LIST_SIZE = 10;
  * - EXPLORE 탭: API(usePublicRetrosQuery)로 공개 회고 목록(isOpen=true)을 페이징 조회
  * - loadMore: 다음 페이지 요청이 가능한 경우에만 currentPage를 증가시켜 무한 스크롤을 지원
  */
-export function useRetroSection(initialSection: RetroSection = RETRO_SECTION.MY_PAGE) {
+export function useRetroSection(
+  initialSection: RetroSection = RETRO_SECTION.MY_PAGE,
+  { enabled = true }: UseRetroSectionOptions = {},
+) {
   const [activeSection, setActiveSection] = useState<RetroSection>(initialSection);
   const [currentPage, setCurrentPage] = useState(RETRO_LIST_PAGE);
   const [fetchedRetros, setFetchedRetros] = useState<Array<MyRetroCardVM | PublicRetroCardVM>>([]);
@@ -31,14 +38,14 @@ export function useRetroSection(initialSection: RetroSection = RETRO_SECTION.MY_
   const myRetrosQuery = useMyRetrosQuery({
     page: currentPage,
     size: RETRO_LIST_SIZE,
-    enabled: isMyPage,
+    enabled: enabled && isMyPage,
   });
 
   const publicRetrosQuery = usePublicRetrosQuery({
     isOpen: true,
     page: currentPage,
     size: RETRO_LIST_SIZE,
-    enabled: !isMyPage,
+    enabled: enabled && !isMyPage,
   });
 
   const currentQuery = isMyPage ? myRetrosQuery : publicRetrosQuery;
@@ -67,10 +74,11 @@ export function useRetroSection(initialSection: RetroSection = RETRO_SECTION.MY_
       : currentPage < totalPages;
 
   const loadMore = useCallback(() => {
+    if (!enabled) return;
     if (!hasMore) return;
     if (currentQuery.isFetching) return;
     setCurrentPage((prev) => prev + 1);
-  }, [currentQuery.isFetching, hasMore]);
+  }, [currentQuery.isFetching, enabled, hasMore]);
 
   const retros = useMemo(() => fetchedRetros, [fetchedRetros]);
 

--- a/src/pages/app-shell/AppShellPage.tsx
+++ b/src/pages/app-shell/AppShellPage.tsx
@@ -15,6 +15,10 @@ interface AppShellHeaderProps {
   onReportClick?: () => void;
 }
 
+interface AppShellContentProps {
+  onReportClick?: () => void;
+}
+
 function AppShellHeader({ onReportClick }: AppShellHeaderProps) {
   const { activeTab } = useTab();
   const { push } = useStackPage();
@@ -62,6 +66,37 @@ function AppShellHeader({ onReportClick }: AppShellHeaderProps) {
   return null;
 }
 
+function AppShellContent({ onReportClick }: AppShellContentProps) {
+  const { activeTab } = useTab();
+
+  return (
+    <div className="relative flex h-dvh w-full flex-col overflow-hidden">
+      <AppShellHeader onReportClick={onReportClick} />
+      <div className="relative flex-1 overflow-hidden">
+        <TabScope
+          tab="home"
+          className="h-full"
+        >
+          <HomePage enabled={activeTab === "home"} />
+        </TabScope>
+        <TabScope
+          tab="retro"
+          className="h-full"
+        >
+          <RetroPage enabled={activeTab === "retro"} />
+        </TabScope>
+        <TabScope
+          tab="profile"
+          className="h-full"
+        >
+          <ProfilePage enabled={activeTab === "profile"} />
+        </TabScope>
+      </div>
+      <BottomNav />
+    </div>
+  );
+}
+
 export function AppShellPage() {
   const [isReportOpen, setIsReportOpen] = useState(false);
   const handleReportClick = () => setIsReportOpen(true);
@@ -75,30 +110,7 @@ export function AppShellPage() {
         pageClassName="py-0"
       >
         <TabRoot initialTab="home">
-          <div className="relative flex h-dvh w-full flex-col overflow-hidden">
-            <AppShellHeader onReportClick={handleReportClick} />
-            <div className="relative flex-1 overflow-hidden">
-              <TabScope
-                tab="home"
-                className="h-full"
-              >
-                <HomePage />
-              </TabScope>
-              <TabScope
-                tab="retro"
-                className="h-full"
-              >
-                <RetroPage />
-              </TabScope>
-              <TabScope
-                tab="profile"
-                className="h-full"
-              >
-                <ProfilePage />
-              </TabScope>
-            </div>
-            <BottomNav />
-          </div>
+          <AppShellContent onReportClick={handleReportClick} />
         </TabRoot>
         <ReportSheet
           open={isReportOpen}

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -5,7 +5,11 @@ import { HomePlanner } from "@/widgets/home-planner";
 import { Icon } from "@/shared/ui/icon";
 import { PlannerEditStackPage } from "./ui/PlannerEditStackPage";
 
-export function HomePage() {
+interface HomePageProps {
+  enabled?: boolean;
+}
+
+export function HomePage({ enabled = true }: HomePageProps) {
   const { push } = useStackPage();
   const homeDate = useHomePlanStore((state) => state.date);
   const dayPlanId = useHomePlanStore((state) => state.dayPlanId);
@@ -25,7 +29,7 @@ export function HomePage() {
 
   return (
     <div className="relative h-full pb-20">
-      <HomePlanner />
+      <HomePlanner enabled={enabled} />
       <div className="pointer-events-none fixed bottom-0 left-1/2 z-[60] w-full max-w-[420px] -translate-x-1/2">
         <div className="pointer-events-auto absolute right-5 bottom-[calc(env(safe-area-inset-bottom)+110px)] flex flex-col items-end gap-3">
           <button

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -13,9 +13,13 @@ import { AuthService } from "@/shared/auth";
 
 import { MyInfoStackPage } from "./MyInfoStackPage";
 
-export function ProfilePage() {
+interface ProfilePageProps {
+  enabled?: boolean;
+}
+
+export function ProfilePage({ enabled = true }: ProfilePageProps) {
   const { push } = useStackPage();
-  const { data: myProfile, isLoading: isProfileLoading } = useMyProfileQuery();
+  const { data: myProfile, isLoading: isProfileLoading } = useMyProfileQuery({ enabled });
   const { handleFileSelect, previewUrl, imageKey, isUploading, loadImageViewUrl } =
     useProfileImagePresign();
   const updateImageMutation = useUpdateMyProfileImageMutation();

--- a/src/pages/retro/RetroPage.tsx
+++ b/src/pages/retro/RetroPage.tsx
@@ -1,5 +1,9 @@
 import { RetroFeed } from "@/widgets/retro-feed";
 
-export function RetroPage() {
-  return <RetroFeed />;
+interface RetroPageProps {
+  enabled?: boolean;
+}
+
+export function RetroPage({ enabled = true }: RetroPageProps) {
+  return <RetroFeed enabled={enabled} />;
 }

--- a/src/widgets/home-planner/ui/HomePlanner.tsx
+++ b/src/widgets/home-planner/ui/HomePlanner.tsx
@@ -9,7 +9,11 @@ import { HomeTaskItem } from "@/entities/day-plan";
 import { useHomePlanner } from "@/features/home";
 import { HomeWeekSelector } from "@/widgets/home-week";
 
-export function HomePlanner() {
+interface HomePlannerProps {
+  enabled?: boolean;
+}
+
+export function HomePlanner({ enabled = true }: HomePlannerProps) {
   const handlePlannerProfileRender = useCallback<ProfilerOnRenderCallback>(
     (id, phase, actualDuration, baseDuration, startTime, commitTime) => {
       if (typeof window !== "undefined" && (window as any).__MOLIP_PROFILE_CAPTURE__) {
@@ -53,7 +57,7 @@ export function HomePlanner() {
     isLoading,
     loadMoreRef,
     isCurrentTaskLoading,
-  } = useHomePlanner();
+  } = useHomePlanner({ enabled });
 
   return (
     <Profiler

--- a/src/widgets/retro-feed/ui/RetroFeed.tsx
+++ b/src/widgets/retro-feed/ui/RetroFeed.tsx
@@ -1,11 +1,16 @@
 "use client";
 
 import { RetroListItemCard, useRetroSection } from "@/features/retro";
+import { RETRO_SECTION } from "@/entities/retro";
 import { useInfiniteScrollTrigger } from "@/shared/hooks";
 import { EmptyStateCard } from "@/shared/ui/empty";
 import { RetroSectionTabs } from "./RetroSectionTabs";
 
-export function RetroFeed() {
+interface RetroFeedProps {
+  enabled?: boolean;
+}
+
+export function RetroFeed({ enabled = true }: RetroFeedProps) {
   const {
     activeSection,
     setActiveSection,
@@ -16,10 +21,10 @@ export function RetroFeed() {
     isFetching,
     hasMore,
     loadMore,
-  } = useRetroSection();
+  } = useRetroSection(RETRO_SECTION.MY_PAGE, { enabled });
 
   const { loadMoreRef } = useInfiniteScrollTrigger<HTMLDivElement>({
-    enabled: true,
+    enabled,
     hasMore,
     isFetching,
     onLoadMore: loadMore,

--- a/src/widgets/tab-stack/ui/TabScope.tsx
+++ b/src/widgets/tab-stack/ui/TabScope.tsx
@@ -11,11 +11,16 @@ interface TabScopeProps {
   tab: AppTab;
   children: ReactNode;
   className?: string;
+  keepMounted?: boolean;
 }
 
-export function TabScope({ tab, children, className }: TabScopeProps) {
+export function TabScope({ tab, children, className, keepMounted = false }: TabScopeProps) {
   const { activeTab } = useTab();
   const isActive = activeTab === tab;
+
+  if (!isActive && !keepMounted) {
+    return null;
+  }
 
   return (
     <div


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- `TabScope` 기본 정책을 비활성 탭 `hidden` 유지에서 `unmount(return null)`로 변경
- `AppShellContent`에서 `activeTab` 기반 `enabled`를 각 탭 페이지(`home/retro/profile`)로 전달
- Home/Retro/Profile 조회 훅 체인에 `enabled`를 전파해 비활성 탭 API 선호출을 이중 차단
- `fcm-tokens`는 전역 세션 정책으로 유지하고 탭 정책과 분리됨을 명시

## 작업 배경/목적

- 비활성 탭이 마운트된 상태로 유지되어 현재 화면이 아닌 API 요청이 선실행되는 버그(#282) 해결
- 탭 진입 시점에만 해당 페이지 요청이 실행되도록 런타임 정책 정렬

## 영향 범위

- `src/widgets/tab-stack/ui/TabScope.tsx`
- `src/pages/app-shell/AppShellPage.tsx`
- `src/pages/home/HomePage.tsx`
- `src/widgets/home-planner/ui/HomePlanner.tsx`
- `src/features/home/model/useHomePlanner.ts`
- `src/features/home/model/useHomePlannerQueries.ts`
- `src/pages/retro/RetroPage.tsx`
- `src/widgets/retro-feed/ui/RetroFeed.tsx`
- `src/features/retro/model/useRetroSection.ts`
- `src/pages/profile/ProfilePage.tsx`
- `app/providers.tsx`

## 테스트/검증

- 로컬 커밋 훅에서 `next lint` 실행 완료(기존 경고만 존재)
- 수동 검증 항목
  - 앱 진입 시 활성 탭 외 API 선요청 미발생
  - 탭 전환 시 해당 탭 API만 실행
  - `fcm-tokens`는 알림 권한 + accessToken 조건에서만 전역 실행

## 관련 이슈

- Closes #282

## 참고 문서/링크

- AppShell 허브: https://github.com/100-hours-a-week/7-team-temporary-fe/wiki/app-shell-feature-index
- 구조도/마운트 정책: https://github.com/100-hours-a-week/7-team-temporary-fe/wiki/app-shell-architecture-map
- 트러블슈팅: https://github.com/100-hours-a-week/7-team-temporary-fe/wiki/app-shell-inactive-tab-network-calls-troubleshooting