### PR TITLE
[auth-proxy #364] refactor: endpoint 서비스 경계 섹션 정렬

### DIFF
--- a/src/shared/api/endpoints.ts
+++ b/src/shared/api/endpoints.ts
@@ -1,3 +1,16 @@
+/**
+ * API 엔드포인트 레지스트리
+ *
+ * ## 서비스 경계 원칙
+ * - 각 그룹은 단일 백엔드 서비스(task 또는 chat)에만 속한다.
+ * - 동일 그룹 내에서 taskPath/chatPath를 혼용하지 않는다.
+ * - 신규 엔드포인트 추가 시 아래 섹션 구분(TASK SERVICE / CHAT SERVICE)을 기준으로 배치한다.
+ *
+ * ## 환경 변수
+ * - NEXT_PUBLIC_API_TASK_BASE_URL : task 서비스 base URL (기본값: /api/task)
+ * - NEXT_PUBLIC_API_CHAT_BASE_URL : chat 서비스 base URL (기본값: /api/chat)
+ */
+
 const configuredTaskApiBaseUrl = process.env.NEXT_PUBLIC_API_TASK_BASE_URL?.trim();
 const configuredChatApiBaseUrl = process.env.NEXT_PUBLIC_API_CHAT_BASE_URL?.trim();
 
@@ -13,17 +26,20 @@ const CHAT_API_BASE_URL = (
     : "/api/chat"
 ).replace(/\/$/, "");
 
-/**
- * task base url + endpoint path 결합 유틸
- */
 const taskPath = (endpoint: string): string => `${TASK_API_BASE_URL}${endpoint}`;
 const chatPath = (endpoint: string): string => `${CHAT_API_BASE_URL}${endpoint}`;
 
 export const Endpoint = {
+  // ─────────────────────────────────────────────────────────────────────────
+  // TASK SERVICE  (taskPath 전용)
+  // 소유: 인증·사용자·일정·알림 도메인
+  // ─────────────────────────────────────────────────────────────────────────
+
   TOKEN: {
     BASE: taskPath("/token"),
     REFRESH: taskPath("/token"),
   },
+
   USER: {
     BASE: taskPath("/users"),
     IMAGE: taskPath("/users/image"),
@@ -34,17 +50,21 @@ export const Endpoint = {
     NICKNAME: taskPath("/users/nickname"),
     PASSWORD: taskPath("/users/password"),
   },
+
   IMAGES: {
     PRESIGNED_URL: taskPath("/images"),
-    VIEW: (imageKey: string) => taskPath(`/images/${imageKey}`), // GET
+    VIEW: (imageKey: string) => taskPath(`/images/${imageKey}`),
   },
+
   TERMS: {
     LIST: taskPath("/terms"),
   },
+
   TERMS_SIGN: {
     LIST: taskPath("/terms-sign"),
     UPDATE: (termsId: number) => taskPath(`/terms-sign/${termsId}`),
   },
+
   DAY_PLAN: {
     SCHEDULE: taskPath("/day-plan/schedule"),
     PERIOD_SCHEDULES: taskPath("/day-plan/period/schedules"),
@@ -54,34 +74,47 @@ export const Endpoint = {
       taskPath(`/day-plan/${dayPlanId}/schedules/ai-arrangement`),
     SCHEDULES_BY_ID: (dayPlanId: number) => taskPath(`/day-plan/${dayPlanId}/schedules`),
   },
+
   SCHEDULE: {
     BASE: taskPath("/schedule"),
     BY_ID: (scheduleId: number) => taskPath(`/schedule/${scheduleId}`),
     CHILDREN: taskPath("/schedule/children"),
   },
+
   FCM: {
     TOKENS: taskPath("/fcm-tokens"),
   },
+
   NOTIFICATIONS: {
     LIST: taskPath("/notifications"),
   },
+
+  ISSUE: {
+    BASE: taskPath("/issue"),
+  },
+
+  RETRO: {
+    BASE: taskPath("/reflections"),
+    LIKES: (reflectionId: number) => taskPath(`/reflections/${reflectionId}/likes`),
+  },
+
   FRIENDS: {
     LIST: taskPath("/friends"),
     DELETE: (friendUserId: number) => taskPath(`/friends/${friendUserId}`),
   },
+
   FRIEND_REQUESTS: {
     LIST: taskPath("/friend-requests"),
     CREATE: (targetUserId: number) => taskPath(`/friend-requests/${targetUserId}`),
     UPDATE: (requestId: number) => taskPath(`/friend-requests/${requestId}`),
     DELETE: (requestId: number) => taskPath(`/friend-requests/${requestId}`),
   },
-  ISSUE: {
-    BASE: taskPath("/issue"),
-  },
-  RETRO: {
-    BASE: taskPath("/reflections"),
-    LIKES: (reflectionId: number) => taskPath(`/reflections/${reflectionId}/likes`),
-  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // CHAT SERVICE  (chatPath 전용)
+  // 소유: 채팅방 도메인
+  // ─────────────────────────────────────────────────────────────────────────
+
   CHAT_ROOMS: {
     PARTICIPANTS: chatPath("/chat-rooms/participants"),
     OWNER_STATUS: (ownerId: number) => chatPath(`/chat-rooms/participants/${ownerId}`),


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- `src/shared/api/endpoints.ts`에 TASK/CHAT 서비스 경계 원칙 주석을 추가했다.
- endpoint 그룹을 서비스 기준(TASK SERVICE / CHAT SERVICE)으로 재정렬했다.
- 그룹 내 `taskPath`/`chatPath` 혼재를 방지하기 위한 구조적 가이드를 코드에 반영했다.

## 작업 배경/목적

- endpoint 레지스트리에서 서비스 경계를 한눈에 읽히게 하고, 신규 추가 시 경계 혼재를 예방하기 위함

## 영향 범위

- `src/shared/api/endpoints.ts`

## 테스트/검증

- pre-commit `next lint` 실행 통과 (기존 경고만 존재)
- endpoint 상수 참조 경로 변경 없음(주석/정렬 중심 리팩토링)

## 관련 이슈

- Closes #364

## 참고 문서/링크

- 
