### PR TITLE
[chat-api #386] feat: /health 헬스체크 엔드포인트 추가

### DIFF
--- a/app/health/route.ts
+++ b/app/health/route.ts
@@ -1,0 +1,12 @@
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return Response.json({
+    status: "ok",
+    timestamp: new Date().toISOString(),
+  });
+}
+
+export function HEAD() {
+  return new Response(null, { status: 200 });
+}


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- Next App Router에 `/health` 헬스체크 엔드포인트를 추가
- `GET /health` 응답: status, timestamp
- `HEAD /health` 응답: 200

## 작업 배경/목적

- 앱 레벨 상태를 프록시 경유 없이 바로 확인할 수 있는 고정 헬스체크 경로를 제공하기 위함

## 영향 범위

- `app/health/route.ts`

## 관련 이슈

- Refs #386

## 참고 문서/링크

- 브랜치: `feature/health-check-386`
