### PR TITLE
[retro-detail #397] fix: 공개 회고 상세 SSR 조회 실패 수정

### DIFF
--- a/src/entities/retro/api/retro.api.ts
+++ b/src/entities/retro/api/retro.api.ts
@@ -20,6 +20,36 @@ interface FetchPublicRetrosParams {
   signal?: AbortSignal;
 }
 
+function trimTrailingSlash(url: string) {
+  return url.replace(/\/$/, "");
+}
+
+function resolvePublicRetroServerBaseUrl() {
+  const configuredPublicBase = process.env.NEXT_PUBLIC_API_TASK_PUBLIC_BASE_URL?.trim();
+  if (configuredPublicBase) return trimTrailingSlash(configuredPublicBase);
+
+  const proxyTaskTarget =
+    process.env.API_PROXY_TASK_TARGET?.trim() || process.env.API_PROXY_TARGET?.trim();
+  if (proxyTaskTarget) return trimTrailingSlash(proxyTaskTarget);
+
+  return null;
+}
+
+function resolvePublicRetroUrl({
+  clientUrl,
+  serverPath,
+}: {
+  clientUrl: string;
+  serverPath: string;
+}) {
+  if (typeof window !== "undefined") return clientUrl;
+
+  const serverBaseUrl = resolvePublicRetroServerBaseUrl();
+  if (!serverBaseUrl) return clientUrl;
+
+  return `${serverBaseUrl}${serverPath}`;
+}
+
 function toRetroListSearchParams({
   isOpen,
   page = 1,
@@ -60,7 +90,13 @@ export async function fetchPublicRetroById(
   reflectionId: number,
   signal?: AbortSignal,
 ): Promise<MyRetroItemResponseDto> {
-  return apiFetch<MyRetroItemResponseDto>(Endpoint.RETRO.BY_ID(reflectionId), { signal });
+  return apiFetch<MyRetroItemResponseDto>(
+    resolvePublicRetroUrl({
+      clientUrl: Endpoint.RETRO.BY_ID(reflectionId),
+      serverPath: `/reflections/${reflectionId}`,
+    }),
+    { signal },
+  );
 }
 
 export async function fetchPublicRetros({
@@ -70,9 +106,13 @@ export async function fetchPublicRetros({
   signal,
 }: FetchPublicRetrosParams = {}): Promise<PublicRetroListResponseDto> {
   const searchParams = toRetroListSearchParams({ isOpen, page, size });
+  const queryString = searchParams.toString();
 
   return apiFetch<PublicRetroListResponseDto>(
-    `${Endpoint.RETRO.PUBLIC_LIST}?${searchParams.toString()}`,
+    resolvePublicRetroUrl({
+      clientUrl: `${Endpoint.RETRO.PUBLIC_LIST}?${queryString}`,
+      serverPath: `/reflections?${queryString}`,
+    }),
     {
       signal,
     },


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- 공개 회고 조회 API(`fetchPublicRetros`, `fetchPublicRetroById`)에 SSR 전용 URL 분기 로직 추가
- 서버에서는 절대 URL, 클라이언트에서는 기존 endpoint를 사용하도록 분리
- 공개 회고 목록 조회 시 `.../reflections/reflections`로 중복 결합되던 경로 문제 보정

## 작업 배경/목적

- 공개 회고 상세 진입 시 SSR fetch에서 notFound로 떨어지는 QA 이슈를 해결하기 위함
- 동시에 목록 조회 URL 중복 결합 버그를 제거해 공개 회고 조회 경로를 안정화하기 위함

## 영향 범위

- 회고 공개 조회 API 레이어
- 공개 회고 목록/상세 페이지의 데이터 조회 경로

## 테스트/검증

- `pnpm exec eslint src/entities/retro/api/retro.api.ts`
- `pnpm exec tsc --noEmit --pretty false`
- pre-commit `next lint` 통과(레포 전역 기존 warning 유지)

## 관련 이슈

- Closes #397

## 참고 문서/링크

- https://github.com/100-hours-a-week/7-team-temporary-fe/issues/397
