### PR TITLE
[chat-api #418] fix: 이미지 메시지 타입 명세 정합성 수정

### DIFF
--- a/src/entities/chat-room/api/mock.ts
+++ b/src/entities/chat-room/api/mock.ts
@@ -372,7 +372,7 @@ const DEFAULT_MESSAGE_SEED: ChatMessageDto[] = [
   },
   {
     messageId: 209,
-    messageType: "FILE",
+    messageType: "IMAGE",
     senderType: "USER",
     senderId: 5,
     content: null,
@@ -394,7 +394,7 @@ const DEFAULT_MESSAGE_SEED: ChatMessageDto[] = [
   },
   {
     messageId: 208,
-    messageType: "FILE",
+    messageType: "IMAGE",
     senderType: "USER",
     senderId: 5,
     content: null,

--- a/src/pages/room/ui/useChatRoomStackPageModel.ts
+++ b/src/pages/room/ui/useChatRoomStackPageModel.ts
@@ -200,7 +200,7 @@ export function useChatRoomStackPageModel({ roomId }: UseChatRoomStackPageModelO
         chatStompSession.sendMessage({
           idempotencyKey,
           roomId,
-          messageType: "FILE",
+          messageType: "IMAGE",
           content: file.name || "image",
           imageKeys: [imageKey],
         });

--- a/src/shared/model/chatMessage.contract.ts
+++ b/src/shared/model/chatMessage.contract.ts
@@ -1,2 +1,2 @@
-export type ChatMessageType = "TEXT" | "FILE" | "IMAGE" | "TEXT_WITH_IMAGES";
+export type ChatMessageType = "TEXT" | "IMAGE";
 export type ChatMessageSenderType = "USER" | "AI" | "SYSTEM";


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- 이미지 메시지 전송 시 WS payload의 `messageType`을 `FILE`에서 `IMAGE`로 변경
- 채팅 메시지 공통 타입 계약을 `TEXT | IMAGE`로 정합성 조정
- 목업 메시지 시드 타입도 `IMAGE`로 통일

## 작업 배경/목적

- 서버 명세(`messageType: IMAGE | TEXT`)와 FE 전송 payload 간 불일치로 인한 전송 거절을 방지하기 위함

## 영향 범위

- 채팅방 메시지 전송 모델
- 채팅 메시지 공통 타입 계약
- 채팅 메시지 목업 데이터

## 테스트/검증

- `pnpm exec eslint src/pages/room/ui/useChatRoomStackPageModel.ts src/entities/chat-room/api/mock.ts src/shared/model/chatMessage.contract.ts`
- WS 전송 payload 확인: `messageType: "IMAGE"`

## 관련 이슈

- Closes #418

## 참고 문서/링크

- https://github.com/100-hours-a-week/7-team-temporary-fe/issues/418
