### PR TITLE
[performance #451] perf: HOME preload 리소스 lazy loading 전환

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -18,10 +18,10 @@ Sentry.init({
   // Define how likely Replay events are sampled.
   // This sets the sample rate to be 10%. You may want this to be 100% while
   // in development and sample at a lower rate in production
-  replaysSessionSampleRate: 0.1,
+  replaysSessionSampleRate: 0.1, //0.1
 
   // Define how likely Replay events are sampled when an error occurs.
-  replaysOnErrorSampleRate: 1.0,
+  replaysOnErrorSampleRate: 1.0, //1.0
 
   // Enable sending user PII (Personally Identifiable Information)
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,7 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   output: "standalone",
   reactStrictMode: true,
+  productionBrowserSourceMaps: true,
 
   compiler: {
     emotion: true,
@@ -70,6 +71,9 @@ export default withSentryConfig(nextConfig, {
 
   // Upload a larger set of source maps for prettier stack traces (increases build time)
   widenClientFileUpload: true,
+  sourcemaps: {
+    deleteSourcemapsAfterUpload: false,
+  },
 
   // Route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
   // This can increase your server load as well as your hosting bill.

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,10 +1,7 @@
 import { useHomePlanStore, useDayPlanReflectionStatusQuery } from "@/entities/day-plan";
-import { RetroWriteStackPage } from "@/pages/retro";
-import { WeeklyReportStackPage } from "@/pages/report";
 import { useStackPage } from "@/widgets/stack";
 import { HomePlanner } from "@/widgets/home-planner";
 import { FloatingActionButton, FloatingActionDock } from "@/shared/ui/button";
-import { PlannerEditStackPage } from "./ui/PlannerEditStackPage";
 
 interface HomePageProps {
   enabled?: boolean;
@@ -18,20 +15,29 @@ export function HomePage({ enabled = true }: HomePageProps) {
     useDayPlanReflectionStatusQuery({ dayPlanId });
 
   const handleOpenPlannerEdit = () => {
-    push(<PlannerEditStackPage />);
+    void (async () => {
+      const { PlannerEditStackPage } = await import("./ui/PlannerEditStackPage");
+      push(<PlannerEditStackPage />);
+    })();
   };
 
   const handleOpenRetroWrite = () => {
-    push(
-      <RetroWriteStackPage
-        baseDate={homeDate}
-        dayPlanId={dayPlanId}
-      />,
-    );
+    void (async () => {
+      const { RetroWriteStackPage } = await import("@/pages/retro/ui/RetroWriteStackPage");
+      push(
+        <RetroWriteStackPage
+          baseDate={homeDate}
+          dayPlanId={dayPlanId}
+        />,
+      );
+    })();
   };
 
   const handleOpenWeeklyReport = () => {
-    push(<WeeklyReportStackPage baseDate={homeDate} />);
+    void (async () => {
+      const { WeeklyReportStackPage } = await import("@/pages/report/WeeklyReportStackPage");
+      push(<WeeklyReportStackPage baseDate={homeDate} />);
+    })();
   };
 
   return (


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- `HomePage`의 스택 페이지 3종(`PlannerEditStackPage`, `RetroWriteStackPage`, `WeeklyReportStackPage`) 정적 import를 클릭 시점 동적 import로 전환
- `next.config.ts`에 `productionBrowserSourceMaps: true` 적용
- Sentry 설정에서 업로드 후 소스맵 삭제 비활성화(`sourcemaps.deleteSourcemapsAfterUpload: false`)

## 작업 배경/목적

- HOME 초기 진입 시 preload/초기 평가 비용을 줄이기 위해 비필수 코드 로드를 사용자 액션 시점으로 지연
- 성능 분석 시 청크 역추적을 위한 소스맵 확인 환경 보강

## 영향 범위

- HOME 진입 후 각 스택 페이지(플래너 편집/회고 작성/주간 리포트) 오픈 경로
- 프로덕션 빌드의 브라우저 소스맵 산출/유지 설정

## 테스트/검증

- `next lint` 실행 (기존 경고 다수, 신규 에러 없음)
- HOME에서 각 FAB/버튼 클릭 시 동적 import 후 페이지 push 동작 확인

## 관련 이슈

- Closes #451

## 참고 문서/링크

- [1차 성능 최적화 지표 점검 문서](docs/wiki/first-performance-optimization-metrics-check.md)
