### PR TITLE
[FE #446] feat: AppShell 탭 페이지 동적 import 분리

### DIFF
--- a/src/pages/app-shell/AppShellPage.tsx
+++ b/src/pages/app-shell/AppShellPage.tsx
@@ -1,16 +1,49 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { useState } from "react";
 
 import { AppHeader, ReportSheet } from "@/widgets/app-header";
 import { BottomNav, TabRoot, TabScope, useTab } from "@/widgets/tab-stack";
 import { StackPageRoot, StackPageScope, useStackPage } from "@/widgets/stack";
-import { FriendStackPage } from "@/pages/friend";
-import { HomePage } from "@/pages/home";
-import { ProfilePage } from "@/pages/profile";
-import { NotificationStackPage } from "@/pages/notification";
-import { RetroPage } from "@/pages/retro";
-import { RoomPage } from "@/pages/room";
+
+interface TabPageProps {
+  enabled?: boolean;
+}
+
+function TabPageFallback() {
+  return (
+    <div
+      className="h-full w-full"
+      aria-hidden
+    />
+  );
+}
+
+const HomePage = dynamic<TabPageProps>(
+  () => import("@/pages/home/HomePage").then((module) => module.HomePage),
+  {
+    loading: TabPageFallback,
+  },
+);
+const RetroPage = dynamic<TabPageProps>(
+  () => import("@/pages/retro/RetroPage").then((module) => module.RetroPage),
+  {
+    loading: TabPageFallback,
+  },
+);
+const RoomPage = dynamic<TabPageProps>(
+  () => import("@/pages/room/RoomPage").then((module) => module.RoomPage),
+  {
+    loading: TabPageFallback,
+  },
+);
+const ProfilePage = dynamic<TabPageProps>(
+  () => import("@/pages/profile/ProfilePage").then((module) => module.ProfilePage),
+  {
+    loading: TabPageFallback,
+  },
+);
 
 interface AppShellHeaderProps {
   onReportClick?: () => void;
@@ -25,9 +58,11 @@ function AppShellHeader({ onReportClick }: AppShellHeaderProps) {
   const { push } = useStackPage();
 
   const handleNotificationClick = async () => {
+    const { NotificationStackPage } = await import("@/pages/notification");
     push(<NotificationStackPage />);
   };
   const handleFriendClick = async () => {
+    const { FriendStackPage } = await import("@/pages/friend");
     push(<FriendStackPage />);
   };
 


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- `AppShellPage`의 탭 페이지(Home/Retro/Room/Profile) 정적 import를 `next/dynamic` 기반 동적 import로 분리
- 친구/알림 스택 페이지를 헤더 클릭 시점 `import()`로 지연 로딩
- 탭 페이지 로딩 중 레이아웃 흔들림 방지를 위해 fallback 적용

## 작업 배경/목적

- `/home` 진입 시 초기 번들에 비활성 탭 코드까지 포함되는 구조를 줄여 초기 로드 부담을 완화
- 이슈 #446의 목표인 home 초기 JS 및 unused JS 감소 검증

## 영향 범위

- `src/pages/app-shell/AppShellPage.tsx`

## 테스트/검증

- 정적 검사
  - `pnpm exec eslint src/pages/app-shell/AppShellPage.tsx`

- 번들 지표 (`next build`)

| 구분 | before | after | delta |
| --- | ---: | ---: | ---: |
| `/home` route size | 27.8 kB | 5.57 kB | -22.23 kB |
| `/home` First Load JS | 504 kB | 382 kB | -122 kB |

- Lighthouse 지표 (`localhost:3000/home`)

| 구분 | before | after | delta |
| --- | ---: | ---: | ---: |
| Performance | 60 | 61 | +1 |
| FCP | 2.8s | 2.8s | 0.0s |
| LCP | 31.2s | 31.2s | 0.0s |
| Speed Index | 8.1s | 8.1s | 0.0s |
| TBT | 180ms | 160ms | -20ms |
| CLS | 0.002 | 0.002 | 0.000 |
| Unused JS | 143,519 B | 122,348 B | -21,171 B |
| Total byte weight | 4,991 KiB | 4,971 KiB | -20 KiB |

## 관련 이슈

- Closes #446

## 참고 문서/링크

- Issue: https://github.com/100-hours-a-week/7-team-temporary-fe/issues/446
- Lighthouse before: `446-before-localhost_3000-20260307T073901 복사본.html` (2026-03-07 07:39 KST)
- Lighthouse after: `446-after-localhost_3000-20260307T075903.html` (2026-03-07 07:59 KST)
