### PR TITLE
[performance #447] refactor: Sentry 클라이언트 지연 초기화 적용

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -2,30 +2,41 @@
 // The added config here will be used whenever a users loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import * as Sentry from "@sentry/nextjs";
+type SentryModule = typeof import("@sentry/nextjs");
 
-Sentry.init({
-  dsn: "https://22003de6335a4b8ca1270fe5fd03c0bb@o4510866997379072.ingest.us.sentry.io/4510866998820864",
+const sentryDsn =
+  "https://22003de6335a4b8ca1270fe5fd03c0bb@o4510866997379072.ingest.us.sentry.io/4510866998820864";
 
-  // Add optional integrations for additional features
-  integrations: [Sentry.replayIntegration()],
+let sentryPromise: Promise<SentryModule> | null = null;
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
+function loadSentry() {
+  if (!sentryPromise) {
+    sentryPromise = import("@sentry/nextjs");
+  }
+  return sentryPromise;
+}
 
-  // Define how likely Replay events are sampled.
-  // This sets the sample rate to be 10%. You may want this to be 100% while
-  // in development and sample at a lower rate in production
-  replaysSessionSampleRate: 0.1, //0.1
+function initSentry() {
+  void loadSentry().then((Sentry) => {
+    Sentry.init({
+      dsn: sentryDsn,
+      tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1,
+      enableLogs: false,
+      sendDefaultPii: true,
+    });
+  });
+}
 
-  // Define how likely Replay events are sampled when an error occurs.
-  replaysOnErrorSampleRate: 1.0, //1.0
+if (typeof window !== "undefined") {
+  // 초기 렌더 이후로 Sentry 초기화를 미뤄 메인 스레드 블로킹을 줄인다.
+  window.setTimeout(initSentry, 1500);
+}
 
-  // Enable sending user PII (Personally Identifiable Information)
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
-  sendDefaultPii: true,
-});
-
-export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;
+export function onRouterTransitionStart(...args: unknown[]) {
+  void loadSentry().then((Sentry) => {
+    const capture = Sentry.captureRouterTransitionStart as
+      | ((...params: unknown[]) => void)
+      | undefined;
+    capture?.(...args);
+  });
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,7 +4,7 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   output: "standalone",
   reactStrictMode: true,
-  productionBrowserSourceMaps: true,
+  productionBrowserSourceMaps: false,
 
   compiler: {
     emotion: true,
@@ -72,7 +72,8 @@ export default withSentryConfig(nextConfig, {
   // Upload a larger set of source maps for prettier stack traces (increases build time)
   widenClientFileUpload: true,
   sourcemaps: {
-    deleteSourcemapsAfterUpload: false,
+    disable: true,
+    deleteSourcemapsAfterUpload: true,
   },
 
   // Route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- `instrumentation-client.ts`에서 Sentry 정적 import 제거 후 dynamic import 기반 지연 초기화 적용
- 초기 렌더 직후가 아닌 1.5초 뒤 Sentry init 수행하도록 변경
- 라우터 전환 캡처는 필요 시점에 Sentry 모듈을 로드해 실행하도록 변경
- `next.config.ts`에서 브라우저 소스맵 비활성화 및 Sentry 소스맵 업로드 비활성화

## 작업 배경/목적

- 공통 초기 청크에서 Sentry 로딩/실행 비용을 줄여 초기 메인 스레드 점유(TBT)를 완화하기 위함
- 불필요한 클라이언트 소스맵 생성으로 인한 빌드/디스크 부담을 줄이기 위함

## 영향 범위

- 클라이언트 에러 수집 초기화 타이밍
- Next/Sentry 빌드 설정

## 테스트/검증

- `pnpm build` 성공
- 공통 First Load JS 감소 확인 (로컬 빌드 기준)

## 성능 측정 결과 (전/후)

### 측정 기준
- 전 지표: 이전 작업(PR #463) 측정 후 지표를 기준선으로 사용
- 후 지표: 본 변경 적용 후 Lighthouse 재측정

### Lighthouse 전/후 비교

| 항목 | 변경 전(기준선) | 변경 후 | 변화량(Δ) |
|---|---:|---:|---:|
| First Contentful Paint (FCP) | 2.8초 | 0.9초 | -1.9초 |
| Largest Contentful Paint (LCP) | 15.0초 | 14.4초 | -0.6초 |
| Total Blocking Time (TBT) | 210밀리초 | 140밀리초 | -70밀리초 |
| Cumulative Layout Shift (CLS) | 0.002 | 0 | -0.002 |
| Speed Index (SI) | 2.8초 | 1.5초 | -1.3초 |

### Lighthouse 리포트 메모
- 성능 점수: `74`
- 진단 영향치: FCP `+10`, LCP `+0`, TBT `+28`, CLS `+25`, SI `+10`
- 안내 문구:
  - `Lighthouse 실행에 영향을 미치는 문제가 발생했습니다.`
  - `IndexedDB에 저장된 데이터가 로드 성능에 영향을 줄 수 있습니다. 시크릿 창에서 페이지를 감사하여 이러한 리소스가 점수에 영향을 주지 않도록 하세요.`

## 관련 이슈

- Closes #447

## 참고 문서/링크

- https://github.com/100-hours-a-week/7-team-temporary-fe/issues/447
