### PR TITLE
[performance #445] refactor: Root Providers 초기 부하 로직 protected 레이아웃 분리

### DIFF
--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect } from "react";
+import type { ReactNode } from "react";
+
+import { useAuthStore } from "@/entities/user";
+import { FcmForegroundListener } from "@/shared/firebase/FcmForegroundListener";
+import { registerFcmToken } from "@/shared/firebase/registerFcmToken";
+import { chatStompSession } from "@/shared/socket";
+
+interface ProtectedLayoutProps {
+  children: ReactNode;
+}
+
+export default function ProtectedLayout({ children }: ProtectedLayoutProps) {
+  const accessToken = useAuthStore((state) => state.accessToken);
+
+  useEffect(() => {
+    if (!accessToken) {
+      chatStompSession.stop({
+        code: "LOGOUT",
+        message: "로그아웃으로 연결을 종료합니다.",
+      });
+      return;
+    }
+
+    chatStompSession.start(accessToken);
+  }, [accessToken]);
+
+  useEffect(() => {
+    return () => {
+      chatStompSession.stop({
+        code: "APP_UNMOUNT",
+        message: "앱 언마운트로 연결을 종료합니다.",
+      });
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!accessToken) return;
+    if (typeof window === "undefined") return;
+    if (!("Notification" in window)) return;
+    if (Notification.permission !== "granted") return;
+
+    let cancelled = false;
+    const run = async () => {
+      if (cancelled) return;
+      await registerFcmToken({ promptPermission: false });
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [accessToken]);
+
+  return (
+    <>
+      <FcmForegroundListener />
+      {children}
+    </>
+  );
+}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -8,13 +8,10 @@ import { ApiError } from "@/shared/api";
 import { AuthRouteWatcher } from "@/features/auth";
 import { AuthService, configureAuthHandlers } from "@/shared/auth";
 import { useAuthStore } from "@/entities/user";
-import { registerFcmToken } from "@/shared/firebase/registerFcmToken";
 import { registerServiceWorker } from "@/shared/pwa/registerServiceWorker";
-import { FcmForegroundListener } from "@/shared/firebase/FcmForegroundListener";
 import { useAiArrangeNoticeStore } from "@/features/home";
 import { useHomePlanStore } from "@/entities/day-plan";
 import { useUserPreferencesStore } from "@/entities/user";
-import { chatStompSession } from "@/shared/socket";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -84,57 +81,10 @@ export function Providers({ children }: { children: React.ReactNode }) {
     prevAccessTokenRef.current = accessToken;
   }, [accessToken, queryClient]);
 
-  useEffect(() => {
-    if (!accessToken) return;
-    if (typeof window === "undefined") return;
-    if (!("Notification" in window)) return;
-    if (Notification.permission !== "granted") return;
-    // FCM 토큰 등록은 AppShell 탭 마운트 정책과 분리된 전역 세션 정책으로 유지한다.
-
-    let cancelled = false;
-    const run = async () => {
-      const registration = await registerServiceWorker();
-      if (!registration || cancelled) return;
-      try {
-        await registerFcmToken({ promptPermission: false });
-      } catch (error) {
-        console.error("[FCM] auto register failed", error);
-      }
-    };
-
-    void run();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [accessToken]);
-
-  useEffect(() => {
-    if (!accessToken) {
-      chatStompSession.stop({
-        code: "LOGOUT",
-        message: "로그아웃으로 연결을 종료합니다.",
-      });
-      return;
-    }
-
-    chatStompSession.start(accessToken);
-  }, [accessToken]);
-
-  useEffect(() => {
-    return () => {
-      chatStompSession.stop({
-        code: "APP_UNMOUNT",
-        message: "앱 언마운트로 연결을 종료합니다.",
-      });
-    };
-  }, []);
-
   return (
     <QueryClientProvider client={queryClient}>
       <ToastProvider>
         <AuthRouteWatcher />
-        <FcmForegroundListener />
         {children}
       </ToastProvider>
       {process.env.NODE_ENV === "development" ? <ReactQueryDevtools initialIsOpen={false} /> : null}


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- Root `app/providers.tsx`에서 소켓/FCM 관련 초기 부하 로직 제거
- `app/(protected)/layout.tsx` 신설 후 protected 라우트에서만 소켓/FCM 초기화 수행
  - socket start/stop
  - unmount cleanup
  - FCM token register
  - `FcmForegroundListener` 렌더

## 작업 배경/목적

- public 라우트 진입 시 불필요한 소켓 연결/FCM 초기화를 방지
- Root 공통 초기화 비용을 줄여 라우트 공통 번들 부담 완화

## 영향 범위

- `app/providers.tsx`
- `app/(protected)/layout.tsx`
- 인증 후 protected 라우트의 소켓/FCM 초기화 타이밍

## 테스트/검증

- `pnpm lint` 실행 (기존 warning만 존재, 신규 에러 없음)
- public 라우트(`/login`, `/sign-up`, `/retro/public`)에서 소켓/FCM 미동작 확인
- protected 라우트(`/home` 등) 진입 시 소켓/FCM 동작 확인

## 성능 측정 (performance 작업 필수)

- 측정 환경: 로컬 Chrome Lighthouse
- 측정 경로(URL): `/home`
- 기준: 이미지 1 = 변경 전, 이미지 2 = 변경 후

| 항목 | 변경 전 (이미지 1) | 변경 후 (이미지 2) | 변화량(Δ) |
|---|---:|---:|---:|
| Performance Score | 74 | 75 | +1 |
| FCP | 0.9초 | 0.9초 | 0.0초 |
| LCP | 14.4초 | 14.4초 | 0.0초 |
| TBT | 140밀리초 | 50밀리초 | -90밀리초 |
| CLS | 0 | 0.002 | +0.002 |
| Speed Index | 1.5초 | 1.1초 | -0.4초 |

## 관련 이슈

- Closes #445

## 참고 문서/링크

- https://github.com/100-hours-a-week/7-team-temporary-fe/issues/445
