### PR TITLE
[performance #468] feat: 홈 인증 세션 복원 경로 적용

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -48,6 +48,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
 
     const bootstrapAuth = async () => {
       try {
+        if (AuthService.restoreFromSession()) return;
         await AuthService.refresh();
       } catch (error) {
         if (!(error instanceof ApiError && error.httpStatus === 401)) {

--- a/src/shared/auth/auth.handlers.ts
+++ b/src/shared/auth/auth.handlers.ts
@@ -6,6 +6,7 @@
  * 그래서 configureAuthHandlers로 실제 구현(entities/user)을 주입하고,
  * shared 코드는 getAccessToken/clearAuth 같은 인터페이스만 사용한다.
  */
+import { clearTokenFromSession, saveTokenToSession } from "./token.storage";
 export type AuthHandlers = {
   getAccessToken?: () => string | undefined;
   setAuthenticated?: (token: string) => void;
@@ -38,6 +39,7 @@ export function getAccessToken() {
  * 보통 refresh 이후 entity/user 스토어 갱신에 사용된다.
  */
 export function setAuthenticated(token: string) {
+  saveTokenToSession(token);
   handlers.setAuthenticated?.(token);
 }
 
@@ -53,5 +55,6 @@ export function setAuthUserId(userId: number) {
  * 로그아웃 또는 401 처리 시 user auth 상태 무효화에 사용된다.
  */
 export function clearAuth() {
+  clearTokenFromSession();
   handlers.clearAuth?.();
 }

--- a/src/shared/auth/auth.service.ts
+++ b/src/shared/auth/auth.service.ts
@@ -1,5 +1,6 @@
 import { ApiError, apiFetch, Endpoint } from "@/shared/api";
 import { clearAuth, setAuthenticated } from "./auth.handlers";
+import { getStoredFreshToken } from "./token.storage";
 
 let refreshPromise: Promise<string> | null = null;
 
@@ -55,6 +56,13 @@ export const AuthService = {
         throw retryError;
       }
     }
+  },
+
+  restoreFromSession(): boolean {
+    const token = getStoredFreshToken();
+    if (!token) return false;
+    setAuthenticated(token);
+    return true;
   },
 
   async logout() {

--- a/src/shared/auth/token.storage.ts
+++ b/src/shared/auth/token.storage.ts
@@ -1,0 +1,41 @@
+const TOKEN_KEY = "molip_at";
+const TOKEN_EXP_KEY = "molip_at_exp";
+
+/** 만료 60초 전부터 refresh 필요로 간주 */
+const REFRESH_THRESHOLD_MS = 60_000;
+
+function getJwtExp(token: string): number | null {
+  try {
+    const payload = JSON.parse(atob(token.split(".")[1])) as { exp?: unknown };
+    return typeof payload.exp === "number" ? payload.exp * 1000 : null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveTokenToSession(token: string): void {
+  if (typeof sessionStorage === "undefined") return;
+  const exp = getJwtExp(token);
+  sessionStorage.setItem(TOKEN_KEY, token);
+  if (exp) {
+    sessionStorage.setItem(TOKEN_EXP_KEY, String(exp));
+  } else {
+    sessionStorage.removeItem(TOKEN_EXP_KEY);
+  }
+}
+
+export function clearTokenFromSession(): void {
+  if (typeof sessionStorage === "undefined") return;
+  sessionStorage.removeItem(TOKEN_KEY);
+  sessionStorage.removeItem(TOKEN_EXP_KEY);
+}
+
+/** 유효한 토큰이 있으면 반환, 없거나 만료 임박이면 null */
+export function getStoredFreshToken(): string | null {
+  if (typeof sessionStorage === "undefined") return null;
+  const token = sessionStorage.getItem(TOKEN_KEY);
+  const exp = sessionStorage.getItem(TOKEN_EXP_KEY);
+  if (!token || !exp) return null;
+  if (Number(exp) - Date.now() <= REFRESH_THRESHOLD_MS) return null;
+  return token;
+}


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- 세션 기반 토큰 저장소(`token.storage`)를 추가했다.
- `setAuthenticated/clearAuth`에서 세션 저장/삭제를 일관되게 수행하도록 연결했다.
- 앱 부트스트랩 시 `AuthService.restoreFromSession()` 우선 복원 경로를 도입했다.

## 작업 배경/목적

- 홈 초기 진입 시 불필요한 refresh 요청 왕복을 줄여 초기 렌더 지연을 완화하기 위함.

## 영향 범위

- 인증 부트스트랩
- 토큰 저장/삭제 경로
- 인증 상태 복원 로직

## 테스트/검증

- `next lint` (커밋 훅) 통과
- 로그인 후 새로고침 시 세션 복원 동작 수동 확인
- 로그아웃 시 세션 토큰 제거 동작 수동 확인

## 성능 측정 (performance 작업 필수)

- 측정 환경: 로컬 Chrome Lighthouse (모바일 프리셋)
- 측정 경로(URL): `/home`

| 항목 | 변경 전 | 변경 후 | 변화량(Δ) |
|---|---:|---:|---:|
| Performance Score | 미측정 | 미측정 | - |
| FCP | 미측정 | 미측정 | - |
| LCP | 미측정 | 미측정 | - |
| TBT | 미측정 | 미측정 | - |
| CLS | 미측정 | 미측정 | - |
| Speed Index | 미측정 | 미측정 | - |

## 관련 이슈

- Closes #468

## 참고 문서/링크

- https://github.com/100-hours-a-week/7-team-temporary-fe/issues/442
