### PR TITLE
[performance #469] refactor: 홈 정적 에셋 캐시 전략 적용

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,10 +1,52 @@
 /* eslint-disable no-undef */
-self.addEventListener("install", () => {
-  self.skipWaiting();
+
+// _next/static/* 는 content hash 기반 불변 파일 → Cache-First 전략
+const STATIC_CACHE = "molip-static-v2";
+const APP_ICON_PATH = "/icons/icon-v2.svg";
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches
+      .open(STATIC_CACHE)
+      .then((cache) => cache.add(APP_ICON_PATH))
+      .catch(() => undefined)
+      .then(() => self.skipWaiting()),
+  );
 });
 
 self.addEventListener("activate", (event) => {
-  event.waitUntil(self.clients.claim());
+  // 이전 버전 캐시 정리
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(keys.filter((key) => key !== STATIC_CACHE).map((key) => caches.delete(key))),
+      )
+      .then(() => self.clients.claim()),
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  if (request.method !== "GET") return;
+
+  const url = new URL(request.url);
+  const isNextStaticAsset = url.pathname.startsWith("/_next/static/");
+  const isAppIcon = url.pathname === APP_ICON_PATH;
+  if (!isNextStaticAsset && !isAppIcon) return;
+
+  event.respondWith(
+    caches.open(STATIC_CACHE).then(async (cache) => {
+      const cached = await cache.match(request);
+      if (cached) return cached;
+
+      const response = await fetch(request);
+      if (response.ok) {
+        cache.put(request, response.clone());
+      }
+      return response;
+    }),
+  );
 });
 
 let messaging = null;


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- 서비스워커에 정적 에셋 캐시(`molip-static-v2`)를 도입했다.
- install 단계에서 `/icons/icon-v2.svg` 선캐시를 추가했다.
- fetch 단계에서 `/_next/static/*` 및 앱 아이콘을 Cache-First로 처리한다.
- activate 단계에서 이전 버전 캐시 정리를 수행한다.

## 작업 배경/목적

- 반복 방문 시 정적 리소스 재요청을 줄여 초기 렌더 구간의 네트워크 병목을 완화하기 위함.

## 영향 범위

- `public/sw.js` 정적 캐시 정책
- 정적 아이콘/next static 리소스 응답 경로

## 테스트/검증

- `node --check public/sw.js` 통과
- 서비스워커 활성화 후 재방문 시 캐시 HIT 동작 수동 확인

## 성능 측정 (performance 작업 필수)

- 측정 환경: 로컬 Chrome Lighthouse (모바일 프리셋)
- 측정 경로(URL): `/home`

| 항목 | 변경 전 | 변경 후 | 변화량(Δ) |
|---|---:|---:|---:|
| Performance Score | 미측정 | 미측정 | - |
| FCP | 미측정 | 미측정 | - |
| LCP | 미측정 | 미측정 | - |
| TBT | 미측정 | 미측정 | - |
| CLS | 미측정 | 미측정 | - |
| Speed Index | 미측정 | 미측정 | - |

## 관련 이슈

- Closes #469

## 참고 문서/링크

- https://github.com/100-hours-a-week/7-team-temporary-fe/issues/442
