### PR TITLE
[performance #471] refactor: 홈 플래너 UI 렌더 경량화

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -69,6 +69,51 @@
 .text-neutral-900 {
   color: var(--color-ink-900) !important;
 }
+
+.shiny-text {
+  display: inline-block;
+}
+
+@keyframes home-task-strike-in {
+  from {
+    transform: translateY(-50%) scaleX(0);
+  }
+  to {
+    transform: translateY(-50%) scaleX(1);
+  }
+}
+
+@keyframes home-task-complete-pop {
+  0% {
+    transform: scale(0.9);
+  }
+  45% {
+    transform: scale(1.08);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.home-task-title-completed::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  height: 1px;
+  background: currentColor;
+  transform: translateY(-50%) scaleX(1);
+  transform-origin: left center;
+}
+
+.home-task-title-strike-animate::after {
+  animation: home-task-strike-in 240ms ease-out;
+}
+
+.home-task-complete-pop-animate {
+  animation: home-task-complete-pop 260ms ease-out;
+}
 }
 
 html {

--- a/src/entities/day-plan-schedule/ui/HomeTaskItem.tsx
+++ b/src/entities/day-plan-schedule/ui/HomeTaskItem.tsx
@@ -1,11 +1,9 @@
-import styled from "@emotion/styled";
 import type { CSSProperties } from "react";
 import { useEffect, useRef, useState } from "react";
-import { css, keyframes } from "@emotion/react";
 
 import { cn } from "@/shared/lib";
-
 import { Icon } from "@/shared/ui/icon";
+
 import type { TaskItemModel } from "../model/taskModels";
 
 interface HomeTaskItemProps {
@@ -46,20 +44,26 @@ export function HomeTaskItem({
   }, [task.isCompleted]);
 
   return (
-    <Card
-      className={cn("text-ink-900", className)}
+    <article
+      className={cn(
+        "text-ink-900 relative z-[1] flex items-start gap-3",
+        variant === "list" ? "border-none bg-transparent pt-[10px] pb-[5px] pl-[5px]" : "bg-white",
+        variant === "card" && task.isFixedTime && "border-[#FF6D6D]",
+        variant === "card" && task.isCompleted && "text-gray-400",
+        className,
+      )}
       style={style}
-      $isCompleted={task.isCompleted}
-      $isFixedTime={task.isFixedTime}
-      $variant={variant}
     >
-      <Row>
-        <CompleteButton
+      <div className="flex w-full items-start gap-3">
+        <button
           type="button"
           aria-pressed={task.isCompleted}
           aria-label={task.isCompleted ? "완료됨" : "완료"}
           onClick={() => onToggleComplete(task.taskId)}
-          $animate={animateComplete}
+          className={cn(
+            "relative z-[1] shrink-0 cursor-pointer rounded-lg border-none bg-transparent p-0 text-xs font-semibold text-white",
+            animateComplete && "home-task-complete-pop-animate",
+          )}
         >
           <Icon
             name={task.isCompleted ? "todo_check" : "todo_unchecked"}
@@ -70,24 +74,39 @@ export function HomeTaskItem({
             )}
             aria-hidden
           />
-        </CompleteButton>
-        <Content>
-          <TitleRow>
-            <Title
-              $isCompleted={task.isCompleted}
-              $variant={variant}
-              $animateComplete={animateComplete}
+        </button>
+        <div className="flex min-w-0 flex-col gap-[7px] leading-4">
+          <div className="flex items-center gap-2">
+            <div
+              className={cn(
+                "relative text-base font-semibold no-underline",
+                task.isCompleted
+                  ? "home-task-title-completed text-gray-400"
+                  : variant === "list"
+                    ? "text-[#541e0f]"
+                    : "",
+                task.isCompleted && animateComplete && "home-task-title-strike-animate",
+              )}
             >
               {task.title}
-            </Title>
-            {task.isUrgent ? <UrgentBadge>중요</UrgentBadge> : null}
-          </TitleRow>
-          <MetaRow $variant={variant}>
-            <MetaValue>{timeValue}</MetaValue>
-          </MetaRow>
-        </Content>
-      </Row>
-    </Card>
+            </div>
+            {task.isUrgent ? (
+              <span className="rounded-full bg-red-100 px-1.5 py-0.5 text-xs font-semibold text-red-600">
+                중요
+              </span>
+            ) : null}
+          </div>
+          <div
+            className={cn(
+              "flex items-center gap-2 text-[13px]",
+              variant === "list" ? "text-[#b8aca4]" : "opacity-70",
+            )}
+          >
+            <span className="font-medium">{timeValue}</span>
+          </div>
+        </div>
+      </div>
+    </article>
   );
 }
 
@@ -102,147 +121,3 @@ function getTimeValue(task: TaskItemModel) {
 
   return EMPTY_TIME_TEXT;
 }
-
-const Card = styled.article<{
-  $isCompleted: boolean;
-  $isFixedTime: boolean;
-  $variant: "card" | "list";
-}>`
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
-  position: relative;
-  z-index: 1;
-  ${({ $variant }) =>
-    $variant === "list"
-      ? `
-    padding: 10px 0 5px 5px;
-    border-radius: 0;
-    border: none;
-    background: transparent;
-  `
-      : `
-    background: #ffffff;
-  `}
-  ${({ $isFixedTime, $variant }) =>
-    $variant === "card" && $isFixedTime ? "border-color: #FF6D6D;" : ""}
-  ${({ $isCompleted, $variant }) => ($variant === "card" && $isCompleted ? "color: #9ca3af;" : "")}
-`;
-
-const Row = styled.div`
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
-  width: 100%;
-`;
-
-const Content = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 7px;
-  line-height: 16px;
-  min-width: 0;
-`;
-
-const TitleRow = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 8px;
-`;
-
-const strikeIn = keyframes`
-  from {
-    transform: translateY(-50%) scaleX(0);
-  }
-  to {
-    transform: translateY(-50%) scaleX(1);
-  }
-`;
-
-const Title = styled.div<{
-  $isCompleted: boolean;
-  $variant: "card" | "list";
-  $animateComplete: boolean;
-}>`
-  font-size: 16px;
-  font-weight: 600;
-  color: ${({ $isCompleted, $variant }) =>
-    $isCompleted ? "#9ca3af" : $variant === "list" ? "#541e0f" : "inherit"};
-  position: relative;
-  text-decoration: none;
-  ${({ $isCompleted, $animateComplete }) =>
-    $isCompleted
-      ? css`
-          &::after {
-            content: "";
-            position: absolute;
-            left: 0;
-            right: 0;
-            top: 50%;
-            height: 1px;
-            background: currentColor;
-            transform: translateY(-50%) scaleX(1);
-            transform-origin: left center;
-            ${$animateComplete
-              ? css`
-                  animation: ${strikeIn} 240ms ease-out;
-                `
-              : ""}
-          }
-        `
-      : ""}
-`;
-
-const UrgentBadge = styled.span`
-  padding: 2px 6px;
-  border-radius: 999px;
-  background: #fee2e2;
-  color: #dc2626;
-  font-size: 12px;
-  font-weight: 600;
-`;
-
-const MetaRow = styled.div<{ $variant: "card" | "list" }>`
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 13px;
-  color: ${({ $variant }) => ($variant === "list" ? "#b8aca4" : "inherit")};
-  opacity: ${({ $variant }) => ($variant === "list" ? 1 : 0.7)};
-`;
-
-const MetaValue = styled.span`
-  font-weight: 500;
-`;
-
-const completePop = keyframes`
-  0% {
-    transform: scale(0.9);
-  }
-  45% {
-    transform: scale(1.08);
-  }
-  100% {
-    transform: scale(1);
-  }
-`;
-
-const CompleteButton = styled.button<{ $animate: boolean }>`
-  border: none;
-  padding: 0;
-  border-radius: 8px;
-  color: #ffffff;
-  font-size: 12px;
-  font-weight: 600;
-  cursor: pointer;
-  background: transparent;
-  flex-shrink: 0;
-  position: relative;
-  z-index: 1;
-  ${({ $animate }) =>
-    $animate
-      ? css`
-          animation: ${completePop} 260ms ease-out;
-        `
-      : ""}
-`;

--- a/src/shared/ui/ShinyText.jsx
+++ b/src/shared/ui/ShinyText.jsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, useRef } from "react";
-import { motion, useMotionValue, useAnimationFrame, useTransform } from "motion/react";
+import { useRef, useEffect } from "react";
 
 const ShinyText = ({
   text,
@@ -11,107 +10,61 @@ const ShinyText = ({
   color = "#b5b5b5",
   shineColor = "#ffffff",
   spread = 120,
-  yoyo = false,
-  pauseOnHover = false,
-  direction = "left",
   delay = 0,
 }) => {
-  const [isPaused, setIsPaused] = useState(false);
-  const progress = useMotionValue(0);
+  const spanRef = useRef(null);
+  const rafRef = useRef(null);
   const elapsedRef = useRef(0);
   const lastTimeRef = useRef(null);
-  const directionRef = useRef(direction === "left" ? 1 : -1);
-
-  const animationDuration = speed * 1000;
-  const delayDuration = delay * 1000;
-
-  useAnimationFrame((time) => {
-    if (disabled || isPaused) {
-      lastTimeRef.current = null;
-      return;
-    }
-
-    if (lastTimeRef.current === null) {
-      lastTimeRef.current = time;
-      return;
-    }
-
-    const deltaTime = time - lastTimeRef.current;
-    lastTimeRef.current = time;
-
-    elapsedRef.current += deltaTime;
-
-    if (yoyo) {
-      const cycleDuration = animationDuration + delayDuration;
-      const fullCycle = cycleDuration * 2;
-      const cycleTime = elapsedRef.current % fullCycle;
-
-      if (cycleTime < animationDuration) {
-        // Forward animation: 0 -> 100
-        const p = (cycleTime / animationDuration) * 100;
-        progress.set(directionRef.current === 1 ? p : 100 - p);
-      } else if (cycleTime < cycleDuration) {
-        // Delay at end
-        progress.set(directionRef.current === 1 ? 100 : 0);
-      } else if (cycleTime < cycleDuration + animationDuration) {
-        // Reverse animation: 100 -> 0
-        const reverseTime = cycleTime - cycleDuration;
-        const p = 100 - (reverseTime / animationDuration) * 100;
-        progress.set(directionRef.current === 1 ? p : 100 - p);
-      } else {
-        // Delay at start
-        progress.set(directionRef.current === 1 ? 0 : 100);
-      }
-    } else {
-      const cycleDuration = animationDuration + delayDuration;
-      const cycleTime = elapsedRef.current % cycleDuration;
-
-      if (cycleTime < animationDuration) {
-        // Animation phase: 0 -> 100
-        const p = (cycleTime / animationDuration) * 100;
-        progress.set(directionRef.current === 1 ? p : 100 - p);
-      } else {
-        // Delay phase - hold at end (shine off-screen)
-        progress.set(directionRef.current === 1 ? 100 : 0);
-      }
-    }
-  });
 
   useEffect(() => {
-    directionRef.current = direction === "left" ? 1 : -1;
-    elapsedRef.current = 0;
-    progress.set(0);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [direction]);
+    if (disabled) return;
 
-  // Transform: p=0 -> 150% (shine off right), p=100 -> -50% (shine off left)
-  const backgroundPosition = useTransform(progress, (p) => `${150 - p * 2}% center`);
+    const animationDuration = speed * 1000;
+    const delayDuration = delay * 1000;
+    const cycleDuration = animationDuration + delayDuration;
 
-  const handleMouseEnter = useCallback(() => {
-    if (pauseOnHover) setIsPaused(true);
-  }, [pauseOnHover]);
+    const animate = (time) => {
+      if (lastTimeRef.current === null) {
+        lastTimeRef.current = time;
+      } else {
+        elapsedRef.current += time - lastTimeRef.current;
+        lastTimeRef.current = time;
+      }
 
-  const handleMouseLeave = useCallback(() => {
-    if (pauseOnHover) setIsPaused(false);
-  }, [pauseOnHover]);
+      const cycleTime = elapsedRef.current % cycleDuration;
+      const p = cycleTime < animationDuration ? (cycleTime / animationDuration) * 100 : 100;
 
-  const gradientStyle = {
-    backgroundImage: `linear-gradient(${spread}deg, ${color} 0%, ${color} 35%, ${shineColor} 50%, ${color} 65%, ${color} 100%)`,
-    backgroundSize: "200% auto",
-    WebkitBackgroundClip: "text",
-    backgroundClip: "text",
-    WebkitTextFillColor: "transparent",
-  };
+      if (spanRef.current) {
+        spanRef.current.style.backgroundPosition = `${150 - p * 2}% center`;
+      }
+
+      rafRef.current = requestAnimationFrame(animate);
+    };
+
+    rafRef.current = requestAnimationFrame(animate);
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      lastTimeRef.current = null;
+      elapsedRef.current = 0;
+    };
+  }, [disabled, speed, delay]);
 
   return (
-    <motion.span
-      className={`inline-block ${className}`}
-      style={{ ...gradientStyle, backgroundPosition }}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
+    <span
+      ref={spanRef}
+      className={`shiny-text ${className}`}
+      style={{
+        backgroundImage: `linear-gradient(${spread}deg, ${color} 0%, ${color} 35%, ${shineColor} 50%, ${color} 65%, ${color} 100%)`,
+        backgroundSize: "200% auto",
+        WebkitBackgroundClip: "text",
+        backgroundClip: "text",
+        WebkitTextFillColor: "transparent",
+        backgroundPosition: "150% center",
+      }}
     >
       {text}
-    </motion.span>
+    </span>
   );
 };
 


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- HomeTaskItem을 Emotion 기반 스타일 구조에서 경량 클래스 구조로 정리했다.
- 완료/취소선 애니메이션 스타일을 전역 CSS 유틸로 이동했다.
- ShinyText 렌더 로직을 단순화해 불필요한 모션 의존/상태 관리를 축소했다.

## 작업 배경/목적

- 홈 플래너 렌더 경로의 스타일 계산 및 실행 비용을 줄여 초기/상호작용 성능을 개선하기 위함.

## 영향 범위

- 홈 플래너 Task 아이템 UI
- 전역 애니메이션 스타일(`app/globals.css`)
- ShinyText 컴포넌트

## 테스트/검증

- `next lint` (커밋 훅) 통과
- 홈 플래너 목록/완료 토글 애니메이션 수동 확인
- ShinyText 시각 효과 동작 수동 확인

## 성능 측정 (performance 작업 필수)

- 측정 환경: 로컬 Chrome Lighthouse (모바일 프리셋)
- 측정 경로(URL): `/home`

| 항목 | 변경 전 | 변경 후 | 변화량(Δ) |
|---|---:|---:|---:|
| Performance Score | 미측정 | 미측정 | - |
| FCP | 미측정 | 미측정 | - |
| LCP | 미측정 | 미측정 | - |
| TBT | 미측정 | 미측정 | - |
| CLS | 미측정 | 미측정 | - |
| Speed Index | 미측정 | 미측정 | - |

## 관련 이슈

- Closes #471

## 참고 문서/링크

- https://github.com/100-hours-a-week/7-team-temporary-fe/issues/442
