### PR TITLE
[FE #477] fix: 회원가입 자동로그인 플로우 로그인 경로 정렬

### DIFF
--- a/src/features/auth/sign-up/model/useSignUpMutation.ts
+++ b/src/features/auth/sign-up/model/useSignUpMutation.ts
@@ -4,13 +4,15 @@ import type { SignUpFormModel, SignUpRequestDto, SignUpResult } from "./types";
 import { toSignUpRequestDto } from "./dto";
 import { mapAuthError } from "../../api/error.mapper";
 
-export function useSignUpMutation(options: { onSuccess?: (data: SignUpResult) => void } = {}) {
+export function useSignUpMutation(
+  options: { onSuccess?: (data: SignUpResult, form: SignUpFormModel) => void } = {},
+) {
   return useApiMutation<SignUpFormModel, SignUpRequestDto, SignUpResult>({
     url: Endpoint.USER.BASE,
     method: "POST",
     dtoFn: toSignUpRequestDto,
     credentials: "include",
-    onSuccess: (data) => options.onSuccess?.(data),
+    onSuccess: (data, form) => options.onSuccess?.(data, form),
     errorMapper: (error) => {
       if (error instanceof ApiError) {
         return mapAuthError(error);

--- a/src/pages/auth/sign-up/SignUpIntroPage.tsx
+++ b/src/pages/auth/sign-up/SignUpIntroPage.tsx
@@ -26,7 +26,7 @@ export function SignUpIntroPage() {
 
   return (
     <SignUpFormContainer
-      onSuccess={(data) => {
+      onSuccess={(data, form) => {
         setSuppressPublicRedirect(true);
         if (typeof data.accessToken === "string" && data.accessToken.length > 0) {
           setAuthenticated(data.accessToken);
@@ -34,7 +34,14 @@ export function SignUpIntroPage() {
             console.warn("[FCM] token register failed after sign up", error);
           });
         }
-        push(<SignUpSuccessPage />);
+        push(
+          <SignUpSuccessPage
+            autoLoginCredential={{
+              email: form.email,
+              password: form.password,
+            }}
+          />,
+        );
       }}
     >
       <SignUpIntroContent />

--- a/src/pages/auth/sign-up/SignUpSuccessPage.tsx
+++ b/src/pages/auth/sign-up/SignUpSuccessPage.tsx
@@ -1,20 +1,27 @@
 "use client";
 
 import { useCallback, useEffect } from "react";
-import { useRouter } from "next/navigation";
 
 import type { AuthState } from "@/entities/user";
 import { useAuthStore } from "@/entities";
-import { AUTH_DEFAULT_AUTHENTICATED_PATH, AUTH_LOGIN_PATH, AuthService } from "@/shared/auth";
+import { useLoginMutation } from "@/features/auth";
 import { FixedActionBar, PrimaryButton } from "@/shared/ui/button";
 import { AnimatedStar } from "./ui/steps/AnimatedStar";
 
-export function SignUpSuccessPage() {
-  const router = useRouter();
+interface SignUpSuccessPageProps {
+  autoLoginCredential?: {
+    email: string;
+    password: string;
+  };
+}
+
+export function SignUpSuccessPage({ autoLoginCredential }: SignUpSuccessPageProps) {
   const accessToken = useAuthStore((state: AuthState) => state.accessToken);
+  const setAuthenticated = useAuthStore((state: AuthState) => state.setAuthenticated);
   const setSuppressPublicRedirect = useAuthStore(
     (state: AuthState) => state.setSuppressPublicRedirect,
   );
+  const loginMutation = useLoginMutation();
   const title = "정보 기입이 완료되었어요!";
   const description = "내 완벽한 하루를\n시작해볼까요?";
 
@@ -26,16 +33,25 @@ export function SignUpSuccessPage() {
   const handleAutoLoginClick = useCallback(async () => {
     try {
       if (!accessToken) {
-        await AuthService.refresh();
+        if (autoLoginCredential?.email && autoLoginCredential.password) {
+          const loginResult = await loginMutation.mutateAsync({
+            email: autoLoginCredential.email,
+            password: autoLoginCredential.password,
+          });
+          setAuthenticated(loginResult.accessToken);
+        }
       }
       setSuppressPublicRedirect(false);
-      router.replace(AUTH_DEFAULT_AUTHENTICATED_PATH);
     } catch (error) {
       console.warn("[SignUpSuccessPage] auto login failed", error);
-      setSuppressPublicRedirect(false);
-      router.replace(AUTH_LOGIN_PATH);
     }
-  }, [accessToken, router, setSuppressPublicRedirect]);
+  }, [
+    accessToken,
+    autoLoginCredential,
+    loginMutation,
+    setAuthenticated,
+    setSuppressPublicRedirect,
+  ]);
 
   return (
     <div className="flex h-full w-full flex-1 flex-col gap-6 px-[30px] pt-5 pb-5">
@@ -50,6 +66,7 @@ export function SignUpSuccessPage() {
       <FixedActionBar>
         <PrimaryButton
           className="w-full"
+          disabled={loginMutation.isPending}
           onClick={() => void handleAutoLoginClick()}
         >
           자동 로그인

--- a/src/pages/auth/sign-up/ui/SignUpFormContainer.tsx
+++ b/src/pages/auth/sign-up/ui/SignUpFormContainer.tsx
@@ -6,7 +6,7 @@ import { createContext, useContext } from "react";
 
 import { FormProvider } from "react-hook-form";
 
-import type { SignUpResult } from "@/features/auth";
+import type { SignUpFormModel, SignUpResult } from "@/features/auth";
 import { useSignUpForm, useSignUpMutation } from "@/features/auth";
 import { useMutationErrorEffect } from "@/shared/query";
 import { useSignUpErrorEffect } from "./useSignUpErrorEffect";
@@ -19,7 +19,7 @@ const SignUpFormContext = createContext<SignUpFormContextValue | null>(null);
 
 interface SignUpFormContainerProps {
   children: ReactNode;
-  onSuccess?: (data: SignUpResult) => void;
+  onSuccess?: (data: SignUpResult, form: SignUpFormModel) => void;
 }
 
 export function SignUpFormContainer({ children, onSuccess }: SignUpFormContainerProps) {

--- a/src/shared/query/useApiMutation.ts
+++ b/src/shared/query/useApiMutation.ts
@@ -9,7 +9,7 @@ interface UseApiMutationProps<TForm, TDto, TResult = void> {
   dtoFn?: (form: TForm) => TDto;
   authRequired?: boolean;
   refreshOnUnauthorized?: boolean;
-  onSuccess?: (data: TResult) => void;
+  onSuccess?: (data: TResult, form: TForm) => void;
   onError?: (error: unknown) => void;
   invalidateKeys?: Array<readonly unknown[]>;
   errorMapper?: (error: unknown) => Error;
@@ -67,11 +67,11 @@ export function useApiMutation<TForm, TDto, TResult = void>({
         throw error;
       }
     },
-    onSuccess: (data) => {
+    onSuccess: (data, variables) => {
       invalidateKeys.forEach((key) => {
         queryClient.invalidateQueries({ queryKey: key });
       });
-      onSuccess?.(data);
+      onSuccess?.(data, variables);
     },
   });
 }


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- 회원가입 성공 콜백에서 제출 폼(`email/password`)을 자동로그인 페이지로 전달하도록 변경
- 자동로그인 버튼 클릭 시 `refresh` 기반 처리 대신 로그인 API(`POST /token`)를 사용하도록 변경
- 자동로그인 성공 시 인증 상태 갱신만 수행하고, 페이지 이동은 기존 로그인 플로우와 동일하게 `AuthRouteWatcher`에 위임

## 작업 배경/목적

- 기존 자동로그인 동작이 로그인 페이지 플로우와 달라 실패 시 `/login`으로 즉시 이동하는 문제를 제거
- 설계 의도(가입 직후 입력한 계정으로 로그인)와 실제 동작을 일치

## 영향 범위

- 회원가입 완료 화면의 `자동 로그인` 버튼 동작
- 회원가입 성공 후 콜백 타입 및 공통 mutation 성공 콜백 시그니처

## 테스트/검증

- eslint: `pnpm exec eslint src/shared/query/useApiMutation.ts src/features/auth/sign-up/model/useSignUpMutation.ts src/pages/auth/sign-up/ui/SignUpFormContainer.tsx src/pages/auth/sign-up/SignUpIntroPage.tsx src/pages/auth/sign-up/SignUpSuccessPage.tsx`
- typecheck: `pnpm exec tsc --noEmit --pretty false`
- 회원가입 완료 후 `자동 로그인` 클릭 시 인증 상태 갱신 후 public route guard를 통해 홈으로 이동하는 흐름 확인

## 성능 측정 (performance 작업 필수)

- 해당 없음 (버그 수정 범위)

## 관련 이슈

- Closes #477

## 참고 문서/링크

- 없음
