### PR TITLE
[performance #479] fix: 로그인 LCP 즉시 렌더 및 회원가입 지연 로드

### DIFF
--- a/app/(public)/login/page.tsx
+++ b/app/(public)/login/page.tsx
@@ -1,5 +1,20 @@
-import { LoginPage } from "@/pages/auth";
+import { LoginPage } from "@/pages/login";
+import { Icon } from "@/shared/ui/icon";
 
 export default function Page() {
-  return <LoginPage />;
+  return (
+    <>
+      <div className="transition-none">
+        <div className="text-xl leading-tight font-bold text-neutral-500">
+          몰입이 시작되는 <br />
+          가장 작은 단위
+        </div>
+        <Icon
+          name="logoDefault"
+          className="h-auto w-full max-w-[200px] shrink"
+        />
+      </div>
+      <LoginPage />
+    </>
+  );
 }

--- a/src/features/auth/login/ui/GoToSignUpButton.tsx
+++ b/src/features/auth/login/ui/GoToSignUpButton.tsx
@@ -2,15 +2,19 @@ import Link from "next/link";
 
 interface GoToSignUpButtonProps {
   onClick?: () => void;
+  onPrepare?: () => void;
 }
 
-export function GoToSignUpButton({ onClick }: GoToSignUpButtonProps) {
+export function GoToSignUpButton({ onClick, onPrepare }: GoToSignUpButtonProps) {
   if (onClick) {
     return (
       <button
         className="text-center text-sm text-gray-600 underline"
         type="button"
         onClick={onClick}
+        onMouseEnter={onPrepare}
+        onFocus={onPrepare}
+        onTouchStart={onPrepare}
       >
         회원가입으로 이동
       </button>

--- a/src/features/auth/login/ui/LoginForm.tsx
+++ b/src/features/auth/login/ui/LoginForm.tsx
@@ -14,6 +14,7 @@ interface LoginFormProps {
   errorMessage: string | null;
   onSubmit: (event?: BaseSyntheticEvent) => void;
   onGoToSignUp?: () => void;
+  onPrepareSignUp?: () => void;
 }
 
 export function LoginForm({
@@ -23,6 +24,7 @@ export function LoginForm({
   errorMessage,
   onSubmit,
   onGoToSignUp,
+  onPrepareSignUp,
 }: LoginFormProps) {
   const emailError = errors.email?.message?.toString();
   const passwordError = errors.password?.message?.toString();
@@ -61,7 +63,10 @@ export function LoginForm({
         </p>
       )}
       <LoginButton isLoading={isSubmitting} />
-      <GoToSignUpButton onClick={onGoToSignUp} />
+      <GoToSignUpButton
+        onClick={onGoToSignUp}
+        onPrepare={onPrepareSignUp}
+      />
       <Link
         className="text-center text-sm text-gray-600 underline"
         href="/retro/public"

--- a/src/features/auth/login/ui/LoginFormContainer.tsx
+++ b/src/features/auth/login/ui/LoginFormContainer.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-
 import type { AuthState } from "@/entities/user";
 import { useAuthStore } from "@/entities";
 import { useMutationErrorEffect } from "@/shared/query";
@@ -12,10 +10,10 @@ import { LoginForm } from "./LoginForm";
 
 interface LoginFormContainerProps {
   onGoToSignUp?: () => void;
+  onPrepareSignUp?: () => void;
 }
 
-export function LoginFormContainer({ onGoToSignUp }: LoginFormContainerProps) {
-  const router = useRouter();
+export function LoginFormContainer({ onGoToSignUp, onPrepareSignUp }: LoginFormContainerProps) {
   const setAuthenticated = useAuthStore((state: AuthState) => state.setAuthenticated);
   const { form, register, errors, isSubmitting, handleSubmit } = useLoginForm();
   const mutation = useLoginMutation({
@@ -37,6 +35,7 @@ export function LoginFormContainer({ onGoToSignUp }: LoginFormContainerProps) {
       errorMessage={null}
       onSubmit={onSubmit}
       onGoToSignUp={onGoToSignUp}
+      onPrepareSignUp={onPrepareSignUp}
     />
   );
 }

--- a/src/pages/auth/login/ui/LoginPage.tsx
+++ b/src/pages/auth/login/ui/LoginPage.tsx
@@ -1,26 +1,35 @@
 "use client";
 
+import { useCallback, useRef } from "react";
+import type { ComponentType } from "react";
+
 import { LoginFormContainer } from "@/features/auth";
-import { SignUpIntroPage } from "@/pages/auth";
-import { Icon } from "@/shared/ui";
 import { useStackPage } from "@/widgets/stack";
 
 export function LoginPage() {
   const { push } = useStackPage();
+  const signUpIntroModulePromiseRef = useRef<Promise<{ SignUpIntroPage: ComponentType }> | null>(
+    null,
+  );
+
+  const preloadSignUpIntroPage = useCallback(() => {
+    if (!signUpIntroModulePromiseRef.current) {
+      signUpIntroModulePromiseRef.current = import("@/pages/sign-up");
+    }
+    return signUpIntroModulePromiseRef.current;
+  }, []);
+
+  const handleGoToSignUp = () => {
+    void (async () => {
+      const { SignUpIntroPage } = await preloadSignUpIntroPage();
+      push(<SignUpIntroPage />);
+    })();
+  };
 
   return (
-    <>
-      <div>
-        <div className="text-xl font-bold text-neutral-500">
-          몰입이 시작되는 <br />
-          가장 작은 단위
-        </div>
-        <Icon
-          name="logoDefault"
-          className="h-auto w-full max-w-[200px] shrink"
-        />
-      </div>
-      <LoginFormContainer onGoToSignUp={() => push(<SignUpIntroPage />)} />
-    </>
+    <LoginFormContainer
+      onGoToSignUp={handleGoToSignUp}
+      onPrepareSignUp={preloadSignUpIntroPage}
+    />
   );
 }

--- a/src/pages/login/index.ts
+++ b/src/pages/login/index.ts
@@ -1,0 +1,1 @@
+export { LoginPage } from "../auth/login";


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- 로그인 상단 헤드라인을 라우트 레벨로 이동해 LCP 텍스트 노출 경로를 단순화함
- 로그인에서 회원가입 진입 컴포넌트를 `import()` 기반 지연 로드로 전환함
- 회원가입 이동 버튼에 hover/focus/touch 사전 로드 트리거를 추가함
- 로그인 전용 엔트리 배럴(`@/pages/login`)을 추가해 import 경계를 분리함

## 작업 배경/목적

- `/login` LCP 후보 텍스트의 초기 렌더 지연을 완화
- 로그인 초기 번들에서 회원가입 관련 코드 혼입을 줄여 초기 평가 비용 완화

## 영향 범위

- `app/(public)/login/page.tsx`
- `src/pages/auth/login/ui/LoginPage.tsx`
- `src/features/auth/login/ui/LoginForm.tsx`
- `src/features/auth/login/ui/GoToSignUpButton.tsx`
- `src/pages/login/index.ts`

## 테스트/검증

- [x] `pnpm exec eslint app/(public)/login/page.tsx src/pages/auth/login/ui/LoginPage.tsx src/features/auth/login/ui/LoginForm.tsx src/features/auth/login/ui/GoToSignUpButton.tsx`
- [ ] 로그인 -> 회원가입 이동(hover/focus/touch 사전 로드 포함) 수동 검증

## 성능 측정 (performance 작업 필수)

- 측정 환경: 로컬 Chrome Lighthouse (모바일 시뮬레이션)
- 측정 경로(URL): `/login`

| 항목 | 변경 전 | 변경 후 | 변화량(Δ) |
|---|---:|---:|---:|
| Performance Score | 측정 예정 | 측정 예정 | 측정 예정 |
| FCP | 측정 예정 | 측정 예정 | 측정 예정 |
| LCP | 측정 예정 | 측정 예정 | 측정 예정 |
| TBT | 측정 예정 | 측정 예정 | 측정 예정 |
| CLS | 측정 예정 | 측정 예정 | 측정 예정 |
| Speed Index | 측정 예정 | 측정 예정 | 측정 예정 |

## 관련 이슈

- Closes #479

## 참고 문서/링크

- https://github.com/100-hours-a-week/7-team-temporary-fe/issues/442
