### PR TITLE
[performance #480] refactor: 공개 라우트 sign-up 엔트리 경계 분리

### DIFF
--- a/app/(public)/sign-up/intro/page.tsx
+++ b/app/(public)/sign-up/intro/page.tsx
@@ -1,4 +1,4 @@
-import { SignUpIntroPage } from "@/pages/auth";
+import { SignUpIntroPage } from "@/pages/sign-up";
 
 export default function Page() {
   return <SignUpIntroPage />;

--- a/app/(public)/sign-up/page.tsx
+++ b/app/(public)/sign-up/page.tsx
@@ -1,4 +1,4 @@
-import { SignUpPage } from "@/pages/auth";
+import { SignUpPage } from "@/pages/sign-up";
 
 export default function Page() {
   return <SignUpPage />;

--- a/src/pages/sign-up/index.ts
+++ b/src/pages/sign-up/index.ts
@@ -1,0 +1,1 @@
+export { SignUpPage, SignUpIntroPage } from "../auth/sign-up";


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- `/sign-up`, `/sign-up/intro` 라우트의 import 경로를 `@/pages/sign-up` 전용 엔트리로 전환함
- `src/pages/sign-up/index.ts` 배럴을 추가해 공개 인증 라우트의 의존 경계를 분리함

## 작업 배경/목적

- 공개 인증 라우트에서 공용 auth 배럴 의존을 축소해 번들 경계를 명확히 유지
- 로그인/회원가입 라우트 간 불필요한 결합 가능성 완화

## 영향 범위

- `app/(public)/sign-up/page.tsx`
- `app/(public)/sign-up/intro/page.tsx`
- `src/pages/sign-up/index.ts`

## 테스트/검증

- [x] 회원가입 진입 라우트 import 경로 변경 컴파일 확인
- [ ] `/sign-up`, `/sign-up/intro` 수동 동작 확인

## 성능 측정 (performance 작업 필수)

- 측정 환경: 로컬 Chrome
- 측정 경로(URL): `/sign-up`, `/sign-up/intro`

| 항목 | 변경 전 | 변경 후 | 변화량(Δ) |
|---|---:|---:|---:|
| Performance Score | 구조 변경 PR | 구조 변경 PR | N/A |
| FCP | 구조 변경 PR | 구조 변경 PR | N/A |
| LCP | 구조 변경 PR | 구조 변경 PR | N/A |
| TBT | 구조 변경 PR | 구조 변경 PR | N/A |
| CLS | 구조 변경 PR | 구조 변경 PR | N/A |
| Speed Index | 구조 변경 PR | 구조 변경 PR | N/A |

## 관련 이슈

- Closes #480

## 참고 문서/링크

- https://github.com/100-hours-a-week/7-team-temporary-fe/issues/442
