### PR TITLE
[performance #483] refactor: public 라우트 번들 경계 분리

### DIFF
--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -1,9 +1,13 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import type { ReactNode } from "react";
 
+import { useQueryClient } from "@tanstack/react-query";
 import { useAuthStore } from "@/entities/user";
+import { useUserPreferencesStore } from "@/entities/user";
+import { useHomePlanStore } from "@/entities/day-plan";
+import { useAiArrangeNoticeStore } from "@/features/home";
 import { chatStompSession } from "@/shared/socket";
 import { useToast } from "@/shared/ui/toast";
 
@@ -14,6 +18,22 @@ interface ProtectedLayoutProps {
 export default function ProtectedLayout({ children }: ProtectedLayoutProps) {
   const accessToken = useAuthStore((state) => state.accessToken);
   const { showToast } = useToast();
+  const queryClient = useQueryClient();
+  const prevAccessTokenRef = useRef<string | undefined>(accessToken);
+
+  useEffect(() => {
+    const prevAccessToken = prevAccessTokenRef.current;
+    if (prevAccessToken && !accessToken) {
+      queryClient.clear();
+      useHomePlanStore.getState().clearHomePlan();
+      useAiArrangeNoticeStore.getState().clearExcludedTitles();
+      useUserPreferencesStore.getState().setSchedulePreferences({
+        dayEndTime: null,
+        focusTimeZone: null,
+      });
+    }
+    prevAccessTokenRef.current = accessToken;
+  }, [accessToken, queryClient]);
 
   useEffect(() => {
     if (!accessToken) {

--- a/app/(public)/layout.tsx
+++ b/app/(public)/layout.tsx
@@ -1,32 +1,9 @@
-"use client";
-
 import type { ReactNode } from "react";
-import { usePathname } from "next/navigation";
-
-import { cn } from "@/shared/lib";
-import { StackPageRoot, StackPageScope } from "@/widgets/stack";
 
 interface AuthLayoutProps {
   children: ReactNode;
 }
 
 export default function AuthLayout({ children }: AuthLayoutProps) {
-  const pathname = usePathname();
-  const isRetroPublicRoute = pathname?.startsWith("/retro/public") ?? false;
-
-  return (
-    <StackPageRoot>
-      <StackPageScope
-        as="main"
-        className={cn(
-          "flex h-dvh w-full flex-col items-center overflow-hidden text-left",
-          isRetroPublicRoute ? "px-0 py-0" : "px-10 py-10",
-        )}
-        pageClassName={cn("bg-white", isRetroPublicRoute && "h-full !py-0")}
-        overlayClassName="bg-white"
-      >
-        {children}
-      </StackPageScope>
-    </StackPageRoot>
-  );
+  return <>{children}</>;
 }

--- a/app/(public)/login/layout.tsx
+++ b/app/(public)/login/layout.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+
+import { StackPageRoot, StackPageScope } from "@/widgets/stack";
+
+interface LoginLayoutProps {
+  children: ReactNode;
+}
+
+export default function LoginLayout({ children }: LoginLayoutProps) {
+  return (
+    <StackPageRoot>
+      <StackPageScope
+        as="main"
+        className="flex h-dvh w-full flex-col items-center overflow-hidden px-10 py-10 text-left"
+        pageClassName="bg-white"
+        overlayClassName="bg-white"
+      >
+        {children}
+      </StackPageScope>
+    </StackPageRoot>
+  );
+}

--- a/app/(public)/retro/public/layout.tsx
+++ b/app/(public)/retro/public/layout.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+
+import { StackPageRoot, StackPageScope } from "@/widgets/stack";
+
+interface RetroPublicLayoutProps {
+  children: ReactNode;
+}
+
+export default function RetroPublicLayout({ children }: RetroPublicLayoutProps) {
+  return (
+    <StackPageRoot>
+      <StackPageScope
+        as="main"
+        className="flex h-dvh w-full flex-col items-center overflow-hidden px-0 py-0 text-left"
+        pageClassName="bg-white h-full !py-0"
+        overlayClassName="bg-white"
+      >
+        {children}
+      </StackPageScope>
+    </StackPageRoot>
+  );
+}

--- a/app/(public)/sign-up/layout.tsx
+++ b/app/(public)/sign-up/layout.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+
+import { StackPageRoot, StackPageScope } from "@/widgets/stack";
+
+interface SignUpLayoutProps {
+  children: ReactNode;
+}
+
+export default function SignUpLayout({ children }: SignUpLayoutProps) {
+  return (
+    <StackPageRoot>
+      <StackPageScope
+        as="main"
+        className="flex h-dvh w-full flex-col items-center overflow-hidden px-10 py-10 text-left"
+        pageClassName="bg-white"
+        overlayClassName="bg-white"
+      >
+        {children}
+      </StackPageScope>
+    </StackPageRoot>
+  );
+}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -2,16 +2,13 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { ToastProvider } from "@/shared/ui/toast";
 import { ApiError } from "@/shared/api";
 import { AuthRouteWatcher } from "@/features/auth";
 import { AuthService, configureAuthHandlers } from "@/shared/auth";
 import { useAuthStore } from "@/entities/user";
 import { registerServiceWorker } from "@/shared/pwa/registerServiceWorker";
-import { useAiArrangeNoticeStore } from "@/features/home";
-import { useHomePlanStore } from "@/entities/day-plan";
-import { useUserPreferencesStore } from "@/entities/user";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -35,9 +32,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
     });
   }, []);
 
-  const accessToken = useAuthStore((state) => state.accessToken);
   const setAuthChecking = useAuthStore((state) => state.setAuthChecking);
-  const prevAccessTokenRef = useRef<string | undefined>(accessToken);
 
   useEffect(() => {
     registerServiceWorker();
@@ -67,20 +62,6 @@ export function Providers({ children }: { children: React.ReactNode }) {
       cancelled = true;
     };
   }, [setAuthChecking]);
-
-  useEffect(() => {
-    const prevAccessToken = prevAccessTokenRef.current;
-    if (prevAccessToken && !accessToken) {
-      queryClient.clear();
-      useHomePlanStore.getState().clearHomePlan();
-      useAiArrangeNoticeStore.getState().clearExcludedTitles();
-      useUserPreferencesStore.getState().setSchedulePreferences({
-        dayEndTime: null,
-        focusTimeZone: null,
-      });
-    }
-    prevAccessTokenRef.current = accessToken;
-  }, [accessToken, queryClient]);
 
   return (
     <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- `app/(public)/layout.tsx`를 서버 레이아웃으로 단순화하고 경로 분기/클라이언트 의존 제거
- `/login`, `/sign-up`, `/retro/public`에 전용 layout을 추가해 StackPageScope 경계 분리
- home 전용 상태 정리 로직을 `providers`에서 `app/(protected)/layout.tsx`로 이동

## 작업 배경/목적

- public 인증 라우트 진입 시 불필요한 경로 분기와 도메인 의존을 줄여 초기 번들 경계를 명확히 분리
- protected 영역에서만 home 도메인 상태 정리 책임을 갖도록 구조 정리

## 영향 범위

- `app/(public)/layout.tsx`
- `app/(public)/login/layout.tsx`
- `app/(public)/sign-up/layout.tsx`
- `app/(public)/retro/public/layout.tsx`
- `app/providers.tsx`
- `app/(protected)/layout.tsx`

## 테스트/검증

- [x] `pnpm exec eslint app/providers.tsx 'app/(public)/layout.tsx' 'app/(protected)/layout.tsx'`
- [ ] `/login`, `/sign-up`, `/retro/public` 레이아웃 진입 수동 확인
- [ ] 로그아웃 후 protected 상태 정리(query/store clear) 동작 수동 확인

## 성능 측정 (performance 작업 필수)

- 측정 환경: Chrome Lighthouse (모바일 스로틀, prod 서버)
- 측정 경로(URL): `/login`, `/sign-up`, `/retro/public`

| 항목 | 변경 전 | 변경 후 | 변화량(Δ) |
|---|---:|---:|---:|
| Performance Score | 측정 예정 | 측정 예정 | 측정 예정 |
| FCP | 측정 예정 | 측정 예정 | 측정 예정 |
| LCP | 측정 예정 | 측정 예정 | 측정 예정 |
| TBT | 측정 예정 | 측정 예정 | 측정 예정 |
| CLS | 측정 예정 | 측정 예정 | 측정 예정 |
| Speed Index | 측정 예정 | 측정 예정 | 측정 예정 |

## 관련 이슈

- Closes #483

## 참고 문서/링크

- https://github.com/100-hours-a-week/7-team-temporary-fe/issues/442
