### PR TITLE
[performance #442] refactor: 홈 초기 번들 의존 경량 엔트리 분리

### DIFF
--- a/src/entities/day-plan-schedule-core/index.ts
+++ b/src/entities/day-plan-schedule-core/index.ts
@@ -1,0 +1,7 @@
+export { dayPlanScheduleQueryKeys } from "../day-plan-schedule/model/queryKeys";
+export { useCurrentScheduleQuery } from "../day-plan-schedule/model/useCurrentScheduleQuery";
+export { useDayPlanScheduleQuery } from "../day-plan-schedule/model/useDayPlanScheduleQuery";
+export type { DayPlanScheduleListModel } from "../day-plan-schedule/model/scheduleModels";
+export { toTaskItemModelFromHomeTask } from "../day-plan-schedule/model/taskMappers";
+export type { TaskItemModel } from "../day-plan-schedule/model/taskModels";
+export { HomeTaskItem } from "../day-plan-schedule/ui/HomeTaskItem";

--- a/src/features/home-core/index.ts
+++ b/src/features/home-core/index.ts
@@ -1,0 +1,9 @@
+export {
+  DAYS_IN_WEEK,
+  WEEKDAY_LABELS,
+  addDays,
+  getRepresentativeMonthIndex,
+  isSameDate,
+  toStartOfWeek,
+} from "../home/model/calendar";
+export { useUpdateScheduleStatusMutation } from "../home/model/useScheduleMutations";

--- a/src/widgets/home-planner/model/date.ts
+++ b/src/widgets/home-planner/model/date.ts
@@ -1,4 +1,4 @@
-import { WEEKDAY_LABELS } from "@/features/home";
+import { WEEKDAY_LABELS } from "@/features/home-core";
 
 export function formatDateToYmd(date: Date) {
   const year = date.getFullYear();

--- a/src/widgets/home-planner/model/useHomePlanner.ts
+++ b/src/widgets/home-planner/model/useHomePlanner.ts
@@ -4,7 +4,7 @@ import {
   dayPlanScheduleQueryKeys,
   toTaskItemModelFromHomeTask,
   type TaskItemModel,
-} from "@/entities/day-plan-schedule";
+} from "@/entities/day-plan-schedule-core";
 import { useHomePlanStore } from "@/entities/day-plan";
 import { useInfiniteScrollTrigger } from "@/shared/hooks";
 import { formatDateToYmd } from "./date";
@@ -13,7 +13,7 @@ import { useHomePlannerQueries } from "./useHomePlannerQueries";
 import { useMergedTasks } from "./useMergedTasks";
 import { toHomeWeekPlanPresenceVM } from "./planPresenceViewModel";
 import { usePlannerStatus } from "./usePlannerStatus";
-import { useUpdateScheduleStatusMutation } from "@/features/home";
+import { useUpdateScheduleStatusMutation } from "@/features/home-core";
 
 const PAGE_SIZE = 10;
 

--- a/src/widgets/home-planner/model/useHomePlannerCalendar.ts
+++ b/src/widgets/home-planner/model/useHomePlannerCalendar.ts
@@ -1,6 +1,11 @@
 import { useCallback, useMemo, useState } from "react";
 
-import { addDays, DAYS_IN_WEEK, getRepresentativeMonthIndex, toStartOfWeek } from "@/features/home";
+import {
+  addDays,
+  DAYS_IN_WEEK,
+  getRepresentativeMonthIndex,
+  toStartOfWeek,
+} from "@/features/home-core";
 
 interface UseHomePlannerCalendarResult {
   today: Date;

--- a/src/widgets/home-planner/model/useHomePlannerQueries.ts
+++ b/src/widgets/home-planner/model/useHomePlannerQueries.ts
@@ -1,4 +1,7 @@
-import { useCurrentScheduleQuery, useDayPlanScheduleQuery } from "@/entities/day-plan-schedule";
+import {
+  useCurrentScheduleQuery,
+  useDayPlanScheduleQuery,
+} from "@/entities/day-plan-schedule-core";
 import { useDayPlanPeriodSchedulesQuery } from "@/entities/day-plan-presence";
 
 interface UseHomePlannerQueriesParams {

--- a/src/widgets/home-planner/model/useMergedTasks.ts
+++ b/src/widgets/home-planner/model/useMergedTasks.ts
@@ -1,7 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
 
-import type { DayPlanScheduleListModel } from "@/entities/day-plan-schedule";
-import { toTaskItemModelFromHomeTask, type TaskItemModel } from "@/entities/day-plan-schedule";
+import {
+  toTaskItemModelFromHomeTask,
+  type DayPlanScheduleListModel,
+  type TaskItemModel,
+} from "@/entities/day-plan-schedule-core";
 
 interface UseMergedTasksParams {
   data?: DayPlanScheduleListModel;

--- a/src/widgets/home-planner/model/usePlannerStatus.ts
+++ b/src/widgets/home-planner/model/usePlannerStatus.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 
-import type { TaskItemModel } from "@/entities/day-plan-schedule";
+import type { TaskItemModel } from "@/entities/day-plan-schedule-core";
 import { formatScheduleLabel } from "./date";
 
 interface PlannerStatusMessage {

--- a/src/widgets/home-planner/ui/HomePlanner.tsx
+++ b/src/widgets/home-planner/ui/HomePlanner.tsx
@@ -6,7 +6,7 @@ import type { CSSProperties, ProfilerOnRenderCallback } from "react";
 import { SectionCard, ShinyText } from "@/shared/ui";
 import { SectionActionButton } from "@/shared/ui/button";
 import { Icon } from "@/shared/ui/icon";
-import { HomeTaskItem } from "@/entities/day-plan-schedule";
+import { HomeTaskItem } from "@/entities/day-plan-schedule-core";
 import { useHomePlanner } from "../model/useHomePlanner";
 import { HomeWeekSelector } from "@/widgets/home-week";
 
@@ -15,12 +15,29 @@ interface HomePlannerProps {
   onWeeklyReportClick?: () => void;
 }
 
+interface MolipProfileEntry {
+  id: string;
+  phase: "mount" | "update" | "nested-update";
+  actualDuration: number;
+  baseDuration: number;
+  startTime: number;
+  commitTime: number;
+}
+
+type MolipProfileWindow = Window & {
+  __MOLIP_PROFILE_CAPTURE__?: boolean;
+  __MOLIP_PROFILE_ENTRIES__?: MolipProfileEntry[];
+};
+
 export function HomePlanner({ enabled = true, onWeeklyReportClick }: HomePlannerProps) {
   const handlePlannerProfileRender = useCallback<ProfilerOnRenderCallback>(
     (id, phase, actualDuration, baseDuration, startTime, commitTime) => {
-      if (typeof window !== "undefined" && (window as any).__MOLIP_PROFILE_CAPTURE__) {
-        const currentEntries = Array.isArray((window as any).__MOLIP_PROFILE_ENTRIES__)
-          ? (window as any).__MOLIP_PROFILE_ENTRIES__
+      if (typeof window !== "undefined") {
+        const profileWindow = window as MolipProfileWindow;
+        if (!profileWindow.__MOLIP_PROFILE_CAPTURE__) return;
+
+        const currentEntries = Array.isArray(profileWindow.__MOLIP_PROFILE_ENTRIES__)
+          ? profileWindow.__MOLIP_PROFILE_ENTRIES__
           : [];
         currentEntries.push({
           id,
@@ -30,7 +47,7 @@ export function HomePlanner({ enabled = true, onWeeklyReportClick }: HomePlanner
           startTime,
           commitTime,
         });
-        (window as any).__MOLIP_PROFILE_ENTRIES__ = currentEntries;
+        profileWindow.__MOLIP_PROFILE_ENTRIES__ = currentEntries;
       }
     },
     [],

--- a/src/widgets/home-week/ui/WeekDateSelector.tsx
+++ b/src/widgets/home-week/ui/WeekDateSelector.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@/shared/lib";
 import { DateSwapText } from "@/shared/ui";
 import { useHomePlanStore } from "@/entities/day-plan";
-import { isSameDate } from "@/features/home";
+import { isSameDate } from "@/features/home-core";
 
 interface WeekDateSelectorProps {
   weekDays: Date[];

--- a/src/widgets/home-week/ui/WeekdayLabels.tsx
+++ b/src/widgets/home-week/ui/WeekdayLabels.tsx
@@ -1,4 +1,4 @@
-import { WEEKDAY_LABELS } from "@/features/home";
+import { WEEKDAY_LABELS } from "@/features/home-core";
 
 export function WeekdayLabels() {
   return (


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- `/home` 초기 경로에서 넓은 배럴 import 의존을 경량 엔트리포인트로 분리
- `day-plan-schedule-core`, `home-core` 엔트리 추가로 초기 그래프 축소
- `home-week`, `home-planner`에서 core 엔트리 기반으로 import 경로 정리
- `HomePlanner` 프로파일 캡처 로직의 `any` 타입 제거

## 작업 배경/목적

- `/home` 진입 시 planner-edit 전용 DnD 코드 청크(`7452`)가 초기 로드 그래프에 섞이는 문제를 줄이기 위함
- 경계 규칙(`boundaries/entry-point`, `no-restricted-imports`)을 유지하면서 초기 번들 의존만 분리하기 위함

## 영향 범위

- `src/widgets/home-planner/**`
- `src/widgets/home-week/**`
- `src/entities/day-plan-schedule-core/index.ts` (신규)
- `src/features/home-core/index.ts` (신규)

## 테스트/검증

- `pnpm lint` (에러 0, 기존 경고만 유지)
- `pnpm build --no-lint` 성공
- `.next` 산출물에서 `/home` 초기 청크 bootstrap 의존성에 `7452` 미포함 확인

## 성능 측정 (performance 작업 필수)

- 측정 환경: local production build (`pnpm build --no-lint`)
- 측정 경로(URL): `/home`

| 항목 | 변경 전 | 변경 후 | 변화량(Δ) |
|---|---:|---:|---:|
| Performance Score | N/A | N/A | N/A |
| FCP | N/A | N/A | N/A |
| LCP | N/A | N/A | N/A |
| TBT | N/A | N/A | N/A |
| CLS | N/A | N/A | N/A |
| Speed Index | N/A | N/A | N/A |
| First Load JS (/home) | 239 kB | 181 kB | -58 kB |

## 관련 이슈

- Resolves #442

## 참고 문서/링크

- 번들 확인: `.next/static/chunks/app/(protected)/home/page-*.js`
- 관련 커밋: `93e05f7`
