### PR TITLE
[chat-api #504] feat: 채팅방 생성 type 쿼리 파라미터 연동

### DIFF
--- a/src/entities/chat-room/api/types.ts
+++ b/src/entities/chat-room/api/types.ts
@@ -3,7 +3,7 @@ import type {
   ChatMessageType as ChatMessageContractType,
 } from "@/shared/model";
 
-export type ChatRoomType = "OPEN_CHAT" | "CAM_STUDY";
+export type ChatRoomType = "OPEN_CHAT" | "CAM_STUDY" | "DIRECT_CHAT";
 export type ChatMessageType = ChatMessageContractType;
 export type ChatMessageSenderType = ChatMessageSenderContractType;
 

--- a/src/features/chat-room-create/model/dto.ts
+++ b/src/features/chat-room-create/model/dto.ts
@@ -4,7 +4,6 @@ export function toCreateChatRoomRequestDto(
   form: CreateChatRoomFormModel,
 ): CreateChatRoomRequestDto {
   return {
-    type: form.type,
     title: form.title,
     description: form.description,
     maxParticipants: Number(form.maxParticipants),

--- a/src/features/chat-room-create/model/types.ts
+++ b/src/features/chat-room-create/model/types.ts
@@ -1,14 +1,15 @@
 import type { ChatRoomType } from "@/entities/chat-room";
 
+export type CreatableChatRoomType = Extract<ChatRoomType, "OPEN_CHAT" | "CAM_STUDY">;
+
 export interface CreateChatRoomFormModel {
-  type: ChatRoomType;
+  type: CreatableChatRoomType;
   title: string;
   description: string;
   maxParticipants: string;
 }
 
 export interface CreateChatRoomRequestDto {
-  type: ChatRoomType;
   title: string;
   description: string;
   maxParticipants: number;
@@ -20,7 +21,7 @@ export interface CreateChatRoomResponseDto {
 }
 
 export interface CreateChatRoomTypeOptionVM {
-  type: ChatRoomType;
+  type: CreatableChatRoomType;
   label: string;
   description: string;
 }

--- a/src/features/chat-room-create/model/useCreateChatRoomMutation.ts
+++ b/src/features/chat-room-create/model/useCreateChatRoomMutation.ts
@@ -14,7 +14,10 @@ export function useCreateChatRoomMutation() {
     CreateChatRoomRequestDto,
     CreateChatRoomResponseDto
   >({
-    url: Endpoint.CHAT_ROOMS.CREATE,
+    url: (form) => {
+      const searchParams = new URLSearchParams({ type: form.type });
+      return `${Endpoint.CHAT_ROOMS.CREATE}?${searchParams.toString()}`;
+    },
     method: "POST",
     dtoFn: toCreateChatRoomRequestDto,
     authRequired: true,

--- a/src/features/chat-room-create/ui/CreateChatRoomForm.tsx
+++ b/src/features/chat-room-create/ui/CreateChatRoomForm.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
 import { ApiError, COMMON_ERROR_CODE, CommonError } from "@/shared/api";
 import { cn } from "@/shared/lib";
 
 import { BaseInput, FormField } from "@/shared/form/ui";
 import { FixedActionBar, PrimaryButton } from "@/shared/ui/button";
 import { useToast } from "@/shared/ui/toast";
+import type { ChatRoomType } from "@/entities/chat-room";
 
 import {
   type CreateChatRoomResponseDto,
@@ -29,7 +30,7 @@ import {
 } from "./constants";
 
 interface CreateChatRoomFormProps {
-  onCreated?: (createdRoom: CreateChatRoomResponseDto) => void;
+  onCreated?: (createdRoom: CreateChatRoomResponseDto, type: ChatRoomType) => void;
 }
 
 function getCreateChatRoomErrorMessage(error: unknown) {
@@ -69,7 +70,7 @@ export function CreateChatRoomForm({ onCreated }: CreateChatRoomFormProps) {
         if (typeof createdRoom?.participantId !== "number") {
           throw new Error("생성된 참가자 식별자가 없습니다.");
         }
-        onCreated?.(createdRoom);
+        onCreated?.(createdRoom, normalizedValues.type);
       } catch (error) {
         showToast(getCreateChatRoomErrorMessage(error), "error");
       }
@@ -85,14 +86,16 @@ export function CreateChatRoomForm({ onCreated }: CreateChatRoomFormProps) {
     submitForm,
   } = useCreateChatRoomForm({ onValid: handleCreateChatRoom });
   const selectedType = watch("type");
-  const maxParticipants = watch("maxParticipants");
   const isCamStudyType = selectedType === "CAM_STUDY";
 
-  useEffect(() => {
-    if (!isCamStudyType) return;
-    if (maxParticipants === "10") return;
-    setValue("maxParticipants", "10", { shouldDirty: true, shouldValidate: true });
-  }, [isCamStudyType, maxParticipants, setValue]);
+  const handleSelectType = useCallback(
+    (type: CreateChatRoomFormModel["type"]) => {
+      setValue("type", type, { shouldDirty: true, shouldValidate: true });
+      if (type !== "CAM_STUDY") return;
+      setValue("maxParticipants", "10", { shouldDirty: true, shouldValidate: true });
+    },
+    [setValue],
+  );
 
   return (
     <>
@@ -117,18 +120,14 @@ export function CreateChatRoomForm({ onCreated }: CreateChatRoomFormProps) {
                   <button
                     key={option.type}
                     type="button"
+                    aria-pressed={isSelected}
                     className={cn(
                       "flex min-h-[84px] flex-col items-start justify-center rounded-xl border px-4 py-3 text-left transition-colors",
                       isSelected
                         ? "border-primary-500 bg-primary-50"
                         : "border-neutral-200 bg-white",
                     )}
-                    onClick={() =>
-                      setValue("type", option.type, {
-                        shouldDirty: true,
-                        shouldValidate: true,
-                      })
-                    }
+                    onClick={() => handleSelectType(option.type)}
                   >
                     <span
                       className={cn(

--- a/src/pages/room/ui/ChatSearchStackPage.tsx
+++ b/src/pages/room/ui/ChatSearchStackPage.tsx
@@ -159,6 +159,10 @@ const CHAT_ROOM_TYPE_BADGE: Record<
     label: "캠 스터디방",
     className: "bg-ink-300",
   },
+  DIRECT_CHAT: {
+    label: "1:1 채팅",
+    className: "bg-ink-300",
+  },
 };
 
 function ChatSearchRoomItem({ room, onClick }: ChatSearchRoomItemProps) {

--- a/src/pages/room/ui/CreateChatRoomStackPage.tsx
+++ b/src/pages/room/ui/CreateChatRoomStackPage.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import { CreateChatRoomForm } from "@/features/chat-room-create";
 import { useStackPage } from "@/widgets/stack";
+import { CamStudyRoomStackPage } from "./CamStudyRoomStackPage";
 import { ChatRoomStackPage } from "./ChatRoomStackPage";
 
 export function CreateChatRoomStackPage() {
@@ -19,14 +20,19 @@ export function CreateChatRoomStackPage() {
 
   return (
     <CreateChatRoomForm
-      onCreated={({ roomId, participantId }) =>
+      onCreated={({ roomId, participantId }, type) => {
+        if (type === "CAM_STUDY") {
+          replace(<CamStudyRoomStackPage roomId={roomId} />);
+          return;
+        }
+
         replace(
           <ChatRoomStackPage
             roomId={roomId}
             initialParticipantId={participantId}
           />,
-        )
-      }
+        );
+      }}
     />
   );
 }


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- 채팅방 생성 API 요청 형식을 `POST /chat-rooms?type=...` 스펙에 맞게 수정
- 생성 요청 body에서 `type/roomType` 제거하고 `title/description/maxParticipants`만 전송
- 생성 성공 후 타입별 라우팅 분기 추가 (`CAM_STUDY`는 캠 스터디 스택으로 진입)
- `ChatRoomType`에 `DIRECT_CHAT` 추가 및 검색 배지 매핑 보강

## 작업 배경/목적

- Swagger 스펙 기준 생성 API의 `type`은 query parameter이며 request body에는 포함되지 않음
- CAM_STUDY 생성이 실패하던 계약 불일치를 제거하고 타입 분기 라우팅까지 완료하기 위함

## 영향 범위

- 채팅방 생성 폼/DTO/mutation
- 채팅방 타입 공통 타입 정의
- 채팅 검색 결과 타입 배지 렌더링
- 생성 완료 후 스택 라우팅

## 테스트/검증

- `pnpm -s exec eslint src/features/chat-room-create/model/types.ts src/features/chat-room-create/model/dto.ts src/features/chat-room-create/model/useCreateChatRoomMutation.ts src/features/chat-room-create/ui/CreateChatRoomForm.tsx src/entities/chat-room/api/types.ts src/pages/room/ui/ChatSearchStackPage.tsx src/pages/room/ui/CreateChatRoomStackPage.tsx`
- `pnpm -s exec tsc --noEmit`

## 성능 측정 (performance 작업 필수)

- 해당 없음 (성능 라벨/이슈 아님)

## 관련 이슈

- Closes #504

## 참고 문서/링크

- Swagger: `POST /chat-rooms` (query `type`: OPEN_CHAT, CAM_STUDY, DIRECT_CHAT)
