### PR TITLE
[cam-study-room #525] feat: CAM_STUDY_ROOM 수정 페이지 진입 연결

### DIFF
--- a/src/pages/room/ui/CamStudyParticipantGrid.tsx
+++ b/src/pages/room/ui/CamStudyParticipantGrid.tsx
@@ -9,14 +9,10 @@ interface CamStudyParticipantGridProps {
 
 export function CamStudyParticipantGrid({ participants }: CamStudyParticipantGridProps) {
   return (
-    <ul
-      dir="rtl"
-      className="mt-3 grid grid-cols-3 gap-3 pb-24 sm:grid-cols-4"
-    >
+    <ul className="mt-3 grid grid-cols-3 gap-3 pb-24 sm:grid-cols-4">
       {participants.map((participant) => (
         <li
           key={`${participant.role}-${participant.userId}`}
-          dir="ltr"
           className="overflow-hidden rounded-2xl"
         >
           <ParticipantCell participant={participant} />

--- a/src/pages/room/ui/CamStudyRoomStackPage.tsx
+++ b/src/pages/room/ui/CamStudyRoomStackPage.tsx
@@ -2,12 +2,14 @@
 
 import { useLayoutEffect } from "react";
 
+import { IconButton } from "@/shared/ui/button";
 import { useStackPage } from "@/widgets/stack";
 
 import { useCamStudyRoomStackPageModel } from "../model/useCamStudyRoomStackPageModel";
 import type { CamStudyRoomSummary } from "../model/camStudyRoom.types";
 import { CamStudyControlDock } from "./CamStudyControlDock";
 import { CamStudyParticipantGrid } from "./CamStudyParticipantGrid";
+import { EditGroupChatRoomStackPage } from "./EditGroupChatRoomStackPage";
 
 interface CamStudyRoomStackPageProps {
   roomId: number;
@@ -20,7 +22,7 @@ export function CamStudyRoomStackPage({
   initialTitle,
   initialSummary,
 }: CamStudyRoomStackPageProps) {
-  const { setHeaderContent, setHeaderRightContent } = useStackPage();
+  const { push, setHeaderContent, setHeaderRightContent } = useStackPage();
   const {
     roomTitle,
     summaryCounts,
@@ -33,12 +35,20 @@ export function CamStudyRoomStackPage({
 
   useLayoutEffect(() => {
     setHeaderContent(<span className="text-[18px] font-semibold text-black">{roomTitle}</span>);
-    setHeaderRightContent(null);
+    setHeaderRightContent(
+      <IconButton
+        icon="more"
+        label="캠 스터디방 설정"
+        onClick={() => push(<EditGroupChatRoomStackPage roomId={roomId} />)}
+        className="p-0"
+        iconClassName="h-7 w-7 text-ink-900 [&>path]:h-[18px] [&>path]:w-[18px]"
+      />,
+    );
     return () => {
       setHeaderContent(null);
       setHeaderRightContent(null);
     };
-  }, [roomTitle, setHeaderContent, setHeaderRightContent]);
+  }, [push, roomId, roomTitle, setHeaderContent, setHeaderRightContent]);
 
   return (
     <section className="scrollbar-hide h-full overflow-y-auto px-6 pt-4 pb-[90px]">


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- CAM_STUDY_ROOM 상세 헤더 우측에 `more` 액션을 추가해 수정 페이지로 진입 가능하도록 연결
- 참여자 그리드의 `dir` 속성(`rtl/ltr`)을 제거해 레이아웃 방향 속성 충돌을 정리

## 작업 배경/목적

- `#525` 완료 기준인 "상세 화면에서 수정 페이지 진입" 경로를 먼저 확보
- 기존 상세 화면 그리드 방향 처리 코드를 정리해 표시 일관성 개선

## 영향 범위

- `src/pages/room/ui/CamStudyRoomStackPage.tsx`
- `src/pages/room/ui/CamStudyParticipantGrid.tsx`

## 테스트/검증

- pre-commit `next lint` 통과(기존 레포 전역 warning만 존재)
- `pnpm eslint src/pages/room/ui/CamStudyRoomStackPage.tsx src/pages/room/ui/CamStudyParticipantGrid.tsx`

## 관련 이슈

- Closes #525

## 참고 문서/링크

- 없음
