### PR TITLE
[cam-study-room #514] fix: 캠 토글 낙관적 UI와 실패 롤백 적용

### DIFF
--- a/src/pages/room/model/useCamStudyRoomStackPageModel.ts
+++ b/src/pages/room/model/useCamStudyRoomStackPageModel.ts
@@ -197,10 +197,29 @@ export function useCamStudyRoomStackPageModel({
   }, []);
 
   const handleToggleMyCamera = useCallback(async () => {
-    if (isMyCameraEnabled) {
-      await unpublishCamera();
-    } else {
-      await publishCamera();
+    const nextEnabled = !isMyCameraEnabled;
+
+    // Optimistic update — STOMP event will confirm when it arrives
+    setParticipants((prev) =>
+      prev.map((p) =>
+        p.isMe ? { ...p, cameraEnabled: nextEnabled, screenVisible: nextEnabled } : p,
+      ),
+    );
+
+    try {
+      if (nextEnabled) {
+        await publishCamera();
+      } else {
+        await unpublishCamera();
+      }
+    } catch (err) {
+      // Revert on failure
+      console.error("[cam-study] camera toggle error", err);
+      setParticipants((prev) =>
+        prev.map((p) =>
+          p.isMe ? { ...p, cameraEnabled: !nextEnabled, screenVisible: !nextEnabled } : p,
+        ),
+      );
     }
   }, [isMyCameraEnabled, publishCamera, unpublishCamera]);
 


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- CAM_STUDY_ROOM 내부 페이지의 내 카메라 토글에 낙관적 UI 갱신을 적용했다.
- 카메라 on/off API 호출 실패 시 참가자 상태(`cameraEnabled`, `screenVisible`)를 즉시 롤백하도록 보정했다.

## 작업 배경/목적

- 토글 직후 STOMP 이벤트 도착 전까지 UI가 늦게 반영되거나, 실패 시 상태가 어긋날 수 있는 구간을 줄이기 위함.

## 영향 범위

- `src/pages/room/model/useCamStudyRoomStackPageModel.ts`

## 테스트/검증

- pre-commit `next lint` 통과 (기존 경고만 존재)

## 성능 측정 (performance 작업 필수)

- 해당 없음 (performance 라벨/이슈 아님)

## 관련 이슈

- Refs #514

## 참고 문서/링크

- 없음
