### PR TITLE
[cam-study-camera #533] fix: CAM_STUDY 카메라 미노출 타이밍 보정

### DIFF
--- a/src/entities/cam-study-room/model/useLiveKitSession.ts
+++ b/src/entities/cam-study-room/model/useLiveKitSession.ts
@@ -75,14 +75,18 @@ export function useLiveKitSession({
   }, [token, livekitUrl]);
 
   const publishCamera = useCallback(async () => {
-    const room = roomRef.current;
-    if (!room || !isConnected || participantId === null) return;
+    if (participantId === null) return;
 
+    // 카메라 캡처는 LiveKit 연결 여부와 무관하게 즉시 실행
     const track = await createLocalVideoTrack();
-    await room.localParticipant.publishTrack(track);
     localTrackRef.current = track;
     setLocalVideoTrack(track);
 
+    // LiveKit 연결된 경우에만 publish + 백엔드 통보
+    const room = roomRef.current;
+    if (!room || !isConnected) return;
+
+    await room.localParticipant.publishTrack(track);
     await Promise.all([
       updateChatRoomParticipantCameraStatus({ participantId, cameraEnabled: true }),
       syncChatRoomVideoSession({ roomId, participantId, sessionId: room.name, published: true }),
@@ -90,20 +94,23 @@ export function useLiveKitSession({
   }, [isConnected, participantId, roomId]);
 
   const unpublishCamera = useCallback(async () => {
-    const room = roomRef.current;
     const track = localTrackRef.current;
-    if (!room || !track || participantId === null) return;
+    if (!track || participantId === null) return;
 
-    await room.localParticipant.unpublishTrack(track);
+    // LiveKit publish 해제 (연결된 경우)
+    const room = roomRef.current;
+    if (room && isConnected) {
+      await room.localParticipant.unpublishTrack(track);
+      await Promise.all([
+        updateChatRoomParticipantCameraStatus({ participantId, cameraEnabled: false }),
+        syncChatRoomVideoSession({ roomId, participantId, sessionId: room.name, published: false }),
+      ]);
+    }
+
     track.stop();
     localTrackRef.current = null;
     setLocalVideoTrack(null);
-
-    await Promise.all([
-      updateChatRoomParticipantCameraStatus({ participantId, cameraEnabled: false }),
-      syncChatRoomVideoSession({ roomId, participantId, sessionId: room.name, published: false }),
-    ]);
-  }, [participantId, roomId]);
+  }, [isConnected, participantId, roomId]);
 
   return { localVideoTrack, remoteVideoTracks, isConnected, publishCamera, unpublishCamera };
 }

--- a/src/pages/room/ui/CamStudyParticipantGrid.tsx
+++ b/src/pages/room/ui/CamStudyParticipantGrid.tsx
@@ -96,19 +96,8 @@ function ActiveCamScreen({
           track={track}
           label={`${participant.nickname} 캠 화면`}
         />
-      ) : participant.profileImageUrl ? (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img
-          src={participant.profileImageUrl}
-          alt={`${participant.nickname} 캠 화면`}
-          loading="lazy"
-          decoding="async"
-          className="h-full w-full object-cover"
-        />
       ) : (
-        <div className="flex h-full items-center justify-center bg-neutral-800 text-xs font-semibold text-white/80">
-          캠 화면
-        </div>
+        <div className="h-full w-full bg-neutral-900" />
       )}
       <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 to-transparent px-2 pt-8 pb-2">
         <span className="block truncate text-xs font-medium text-white">


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- 카메라 ON 시 로컬 트랙을 연결 상태와 분리해 즉시 생성/표시하도록 보정했다.
- LiveKit 미연결 상태에서는 publish/백엔드 동기화를 건너뛰고, 연결 시점 이후 정상 publish 흐름으로 이어지게 정리했다.
- 카메라 화면에 track이 없을 때 fallback 렌더 정책을 검은 화면으로 통일했다.

## 작업 배경/목적

- CAM_STUDY_ROOM에서 카메라 토글 직후 화면 미노출(빈 화면)로 보이는 타이밍 이슈를 줄이기 위함.

## 영향 범위

- `src/entities/cam-study-room/model/useLiveKitSession.ts`
- `src/pages/room/ui/CamStudyParticipantGrid.tsx`

## 테스트/검증

- `pnpm -s tsc --noEmit` 통과
- pre-commit `next lint` 통과(기존 경고만 존재)

## 성능 측정 (performance 작업 필수)

- 해당 없음 (performance 작업 아님)

## 관련 이슈

- Closes #533
- Refs #514

## 참고 문서/링크

- 없음
