### PR TITLE
[auth #545] fix: randomUUID 미지원 환경 UUID 폴백 적용

### DIFF
--- a/src/features/chat-room-session/model/useChatRoomSessionModel.ts
+++ b/src/features/chat-room-session/model/useChatRoomSessionModel.ts
@@ -14,6 +14,7 @@ import {
 import type { ChatRoomListModel } from "@/entities/chat-room";
 import { useAuthStore } from "@/entities/user";
 import { requestPresignedUrl, uploadToPresignedUrl } from "@/shared/api";
+import { createUuid } from "@/shared/lib";
 import { chatStompSession } from "@/shared/socket";
 import { useToast } from "@/shared/ui/toast";
 
@@ -25,10 +26,7 @@ const CHAT_ROOM_STACK_INTERACTIVE_DELAY_MS = 220;
 type PendingMessagePayload = Pick<ChatMessageItemVM, "messageType" | "content" | "imageUrls">;
 
 function createIdempotencyKey() {
-  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
-    return crypto.randomUUID();
-  }
-  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return createUuid();
 }
 
 function toRoomFeedPreviewFromPendingMessage(message: ChatMessageItemVM): string {

--- a/src/shared/device/deviceId.ts
+++ b/src/shared/device/deviceId.ts
@@ -1,3 +1,5 @@
+import { createUuid } from "@/shared/lib";
+
 const DEVICE_ID_STORAGE_KEY = "deviceId";
 
 /**
@@ -11,11 +13,11 @@ export function getOrCreateDeviceId(): string {
     const existing = window.localStorage.getItem(DEVICE_ID_STORAGE_KEY);
     if (existing) return existing;
 
-    const created = window.crypto.randomUUID();
+    const created = createUuid();
     window.localStorage.setItem(DEVICE_ID_STORAGE_KEY, created);
     return created;
   } catch (error) {
     console.warn("[device] deviceId storage failed", error);
-    return window.crypto.randomUUID();
+    return createUuid();
   }
 }

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -2,3 +2,4 @@ export * from "./utils";
 export * from "./date";
 export * from "./time";
 export * from "./calendar";
+export * from "./uuid";

--- a/src/shared/lib/uuid.ts
+++ b/src/shared/lib/uuid.ts
@@ -1,0 +1,32 @@
+function fallbackMathRandomUuid(): string {
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (character) => {
+    const random = Math.floor(Math.random() * 16);
+    const nibble = character === "x" ? random : (random & 0x3) | 0x8;
+    return nibble.toString(16);
+  });
+}
+
+function fallbackCryptoUuid(cryptoApi: Crypto): string {
+  const bytes = new Uint8Array(16);
+  cryptoApi.getRandomValues(bytes);
+
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+export function createUuid(): string {
+  const cryptoApi = globalThis.crypto;
+  if (cryptoApi && typeof cryptoApi.randomUUID === "function") {
+    return cryptoApi.randomUUID();
+  }
+
+  if (cryptoApi && typeof cryptoApi.getRandomValues === "function") {
+    return fallbackCryptoUuid(cryptoApi);
+  }
+
+  return fallbackMathRandomUuid();
+}

--- a/src/shared/ui/toast/ToastProvider.tsx
+++ b/src/shared/ui/toast/ToastProvider.tsx
@@ -2,6 +2,8 @@
 
 import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from "react";
 
+import { createUuid } from "@/shared/lib";
+
 import { ToastViewport } from "./ToastViewport";
 
 import type { Toast, ToastType } from "./types";
@@ -22,7 +24,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   const TOAST_DURATION_MS = 3000;
 
   const showToast = useCallback((message: string, type: ToastType = "info") => {
-    const id = crypto.randomUUID();
+    const id = createUuid();
 
     setToasts((prev) => [...prev, { id, message, type, duration: TOAST_DURATION_MS }]);
 

--- a/src/widgets/stack/model/useStackPageState.ts
+++ b/src/widgets/stack/model/useStackPageState.ts
@@ -3,10 +3,12 @@
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { createUuid } from "@/shared/lib";
+
 import { STACK_PAGE_EXIT_MS } from "./constants";
 import type { StackEntry, StackPageContextValue } from "./stackPageContext";
 
-const createStackKey = () => crypto.randomUUID();
+const createStackKey = () => createUuid();
 
 export function useStackPageState(): StackPageContextValue {
   const [stack, setStack] = useState<StackEntry[]>([]);


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- `src/shared/lib/uuid.ts`에 `createUuid` 공통 유틸을 추가하고 UUID 생성 fallback 체계를 도입했다.
- `crypto.randomUUID` 직접 호출 지점을 공통 유틸로 치환했다.
- `src/shared/lib/index.ts`에 `uuid` export를 추가해 공용 import 경로를 통일했다.

## 작업 배경/목적

- 쿠버네티스 배포 환경의 회원가입 페이지에서 `TypeError: crypto.randomUUID is not a function` 런타임 오류가 발생했다.
- 런타임 지원 차이에 관계없이 StackPage key/토스트/디바이스ID/메시지 idempotency key 생성이 동작하도록 보강이 필요했다.

## 영향 범위

- StackPage key 생성: `src/widgets/stack/model/useStackPageState.ts`
- 토스트 ID 생성: `src/shared/ui/toast/ToastProvider.tsx`
- 디바이스 ID 생성: `src/shared/device/deviceId.ts`
- 채팅 idempotency key 생성: `src/features/chat-room-session/model/useChatRoomSessionModel.ts`

## 테스트/검증

- `pnpm exec eslint src/features/chat-room-session/model/useChatRoomSessionModel.ts src/shared/device/deviceId.ts src/shared/lib/index.ts src/shared/lib/uuid.ts src/shared/ui/toast/ToastProvider.tsx src/widgets/stack/model/useStackPageState.ts` 통과
- `pnpm exec next typegen` 통과
- `pnpm exec tsc --noEmit` 실패 (기존 `.next/types/app/(protected)/retro-ssr-test/page.ts` 모듈 해상도 오류)

## 관련 이슈

- Closes #545

## 참고 문서/링크

- 이슈: https://github.com/100-hours-a-week/7-team-temporary-fe/issues/545
