### PR TITLE
release(2.0.2): develop 최신 변경 반영

### DIFF
--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -16,14 +16,14 @@ interface ProtectedLayoutProps {
 }
 
 export default function ProtectedLayout({ children }: ProtectedLayoutProps) {
-  const accessToken = useAuthStore((state) => state.accessToken);
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const { showToast } = useToast();
   const queryClient = useQueryClient();
-  const prevAccessTokenRef = useRef<string | undefined>(accessToken);
+  const prevIsAuthenticatedRef = useRef<boolean>(isAuthenticated);
 
   useEffect(() => {
-    const prevAccessToken = prevAccessTokenRef.current;
-    if (prevAccessToken && !accessToken) {
+    const prev = prevIsAuthenticatedRef.current;
+    if (prev && !isAuthenticated) {
       queryClient.clear();
       useHomePlanStore.getState().clearHomePlan();
       useAiArrangeNoticeStore.getState().clearExcludedTitles();
@@ -32,11 +32,11 @@ export default function ProtectedLayout({ children }: ProtectedLayoutProps) {
         focusTimeZone: null,
       });
     }
-    prevAccessTokenRef.current = accessToken;
-  }, [accessToken, queryClient]);
+    prevIsAuthenticatedRef.current = isAuthenticated;
+  }, [isAuthenticated, queryClient]);
 
   useEffect(() => {
-    if (!accessToken) {
+    if (!isAuthenticated) {
       chatStompSession.stop({
         code: "LOGOUT",
         message: "로그아웃으로 연결을 종료합니다.",
@@ -44,8 +44,8 @@ export default function ProtectedLayout({ children }: ProtectedLayoutProps) {
       return;
     }
 
-    chatStompSession.start(accessToken);
-  }, [accessToken]);
+    chatStompSession.start();
+  }, [isAuthenticated]);
 
   useEffect(() => {
     return () => {
@@ -57,7 +57,7 @@ export default function ProtectedLayout({ children }: ProtectedLayoutProps) {
   }, []);
 
   useEffect(() => {
-    if (!accessToken) return;
+    if (!isAuthenticated) return;
     if (typeof window === "undefined") return;
     if (!("Notification" in window)) return;
     if (Notification.permission !== "granted") return;
@@ -75,7 +75,7 @@ export default function ProtectedLayout({ children }: ProtectedLayoutProps) {
     return () => {
       cancelled = true;
     };
-  }, [accessToken]);
+  }, [isAuthenticated]);
 
   useEffect(() => {
     let cancelled = false;

--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+/**
+ * AT HttpOnly 쿠키 유효성을 확인하고, 소켓 핸드셰이크에 필요한 deviceId를 반환한다.
+ * 클라이언트가 HttpOnly 쿠키를 직접 읽을 수 없어서 인증 부트스트랩 단계에서 사용된다.
+ */
+export async function GET(req: NextRequest) {
+  const token = req.cookies.get("accessToken")?.value;
+  if (!token) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+  const deviceId = req.cookies.get("deviceId")?.value ?? null;
+  return NextResponse.json({ deviceId });
+}

--- a/app/api/bff/_lib.ts
+++ b/app/api/bff/_lib.ts
@@ -11,6 +11,7 @@ const REQUEST_HEADER_ALLOWLIST = new Set([
   "user-agent",
   "x-correlation-id",
   "x-request-id",
+  "x-xsrf-token",
 ]);
 
 const RESPONSE_HOP_BY_HOP_HEADERS = new Set([

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -25,8 +25,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     configureAuthHandlers({
-      getAccessToken: () => useAuthStore.getState().accessToken,
-      setAuthenticated: (token) => useAuthStore.getState().setAuthenticated(token),
+      setAuthenticated: () => useAuthStore.getState().setAuthenticated(),
       setUserId: (userId) => useAuthStore.getState().setUserId(userId),
       clearAuth: () => useAuthStore.getState().clearAuth(),
     });
@@ -43,7 +42,9 @@ export function Providers({ children }: { children: React.ReactNode }) {
 
     const bootstrapAuth = async () => {
       try {
-        if (AuthService.restoreFromSession()) return;
+        // 1순위: AT 쿠키가 살아있으면 refresh 없이 복원 (네트워크 1회)
+        if (await AuthService.restoreFromCookie()) return;
+        // 2순위: RT 쿠키로 AT 재발급
         await AuthService.refresh();
       } catch (error) {
         if (!(error instanceof ApiError && error.httpStatus === 401)) {

--- a/src/entities/user/model/auth.store.ts
+++ b/src/entities/user/model/auth.store.ts
@@ -1,12 +1,11 @@
 import { create } from "zustand";
 
 export interface AuthState {
-  accessToken?: string;
   userId?: number;
   isAuthenticated: boolean;
   isAuthChecking: boolean;
   suppressPublicRedirect: boolean;
-  setAuthenticated: (token: string) => void;
+  setAuthenticated: () => void;
   setUserId: (userId: number) => void;
   clearAuth: () => void;
   setSuppressPublicRedirect: (value: boolean) => void;
@@ -14,17 +13,14 @@ export interface AuthState {
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
-  accessToken: undefined,
   userId: undefined,
   isAuthenticated: false,
   isAuthChecking: true,
   suppressPublicRedirect: false,
-  setAuthenticated: (token) =>
-    set({ accessToken: token, isAuthenticated: true, isAuthChecking: false }),
+  setAuthenticated: () => set({ isAuthenticated: true, isAuthChecking: false }),
   setUserId: (userId) => set({ userId }),
   clearAuth: () =>
     set({
-      accessToken: undefined,
       userId: undefined,
       isAuthenticated: false,
       isAuthChecking: false,

--- a/src/features/auth/guard/ui/AuthRouteWatcher.tsx
+++ b/src/features/auth/guard/ui/AuthRouteWatcher.tsx
@@ -9,7 +9,7 @@ import { AUTH_DEFAULT_AUTHENTICATED_PATH, AUTH_LOGIN_PATH, isAuthPublicPath } fr
 export function AuthRouteWatcher() {
   const router = useRouter();
   const pathname = usePathname();
-  const accessToken = useAuthStore((state) => state.accessToken);
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const isAuthChecking = useAuthStore((state) => state.isAuthChecking);
   const suppressPublicRedirect = useAuthStore((state) => state.suppressPublicRedirect);
 
@@ -19,15 +19,15 @@ export function AuthRouteWatcher() {
 
     const isPublic = isAuthPublicPath(pathname);
 
-    if (!accessToken && !isPublic) {
+    if (!isAuthenticated && !isPublic) {
       router.replace(AUTH_LOGIN_PATH);
       return;
     }
 
-    if (accessToken && isPublic && !suppressPublicRedirect) {
+    if (isAuthenticated && isPublic && !suppressPublicRedirect) {
       router.replace(AUTH_DEFAULT_AUTHENTICATED_PATH);
     }
-  }, [accessToken, isAuthChecking, pathname, router, suppressPublicRedirect]);
+  }, [isAuthenticated, isAuthChecking, pathname, router, suppressPublicRedirect]);
 
   return null;
 }

--- a/src/features/auth/login/ui/LoginFormContainer.tsx
+++ b/src/features/auth/login/ui/LoginFormContainer.tsx
@@ -17,8 +17,8 @@ export function LoginFormContainer({ onGoToSignUp, onPrepareSignUp }: LoginFormC
   const setAuthenticated = useAuthStore((state: AuthState) => state.setAuthenticated);
   const { form, register, errors, isSubmitting, handleSubmit } = useLoginForm();
   const mutation = useLoginMutation({
-    onSuccess: (data) => {
-      setAuthenticated(data.accessToken);
+    onSuccess: () => {
+      setAuthenticated();
     },
   });
 

--- a/src/pages/auth/sign-up/SignUpIntroPage.tsx
+++ b/src/pages/auth/sign-up/SignUpIntroPage.tsx
@@ -28,12 +28,10 @@ export function SignUpIntroPage() {
     <SignUpFormContainer
       onSuccess={(data, form) => {
         setSuppressPublicRedirect(true);
-        if (typeof data.accessToken === "string" && data.accessToken.length > 0) {
-          setAuthenticated(data.accessToken);
-          void registerFcmToken({ promptPermission: true }).catch((error) => {
-            console.warn("[FCM] token register failed after sign up", error);
-          });
-        }
+        setAuthenticated();
+        void registerFcmToken({ promptPermission: true }).catch((error) => {
+          console.warn("[FCM] token register failed after sign up", error);
+        });
         push(
           <SignUpSuccessPage
             autoLoginCredential={{

--- a/src/pages/auth/sign-up/SignUpSuccessPage.tsx
+++ b/src/pages/auth/sign-up/SignUpSuccessPage.tsx
@@ -16,7 +16,7 @@ interface SignUpSuccessPageProps {
 }
 
 export function SignUpSuccessPage({ autoLoginCredential }: SignUpSuccessPageProps) {
-  const accessToken = useAuthStore((state: AuthState) => state.accessToken);
+  const isAuthenticated = useAuthStore((state: AuthState) => state.isAuthenticated);
   const setAuthenticated = useAuthStore((state: AuthState) => state.setAuthenticated);
   const setSuppressPublicRedirect = useAuthStore(
     (state: AuthState) => state.setSuppressPublicRedirect,
@@ -32,13 +32,13 @@ export function SignUpSuccessPage({ autoLoginCredential }: SignUpSuccessPageProp
 
   const handleAutoLoginClick = useCallback(async () => {
     try {
-      if (!accessToken) {
+      if (!isAuthenticated) {
         if (autoLoginCredential?.email && autoLoginCredential.password) {
-          const loginResult = await loginMutation.mutateAsync({
+          await loginMutation.mutateAsync({
             email: autoLoginCredential.email,
             password: autoLoginCredential.password,
           });
-          setAuthenticated(loginResult.accessToken);
+          setAuthenticated();
         }
       }
       setSuppressPublicRedirect(false);
@@ -46,7 +46,7 @@ export function SignUpSuccessPage({ autoLoginCredential }: SignUpSuccessPageProp
       console.warn("[SignUpSuccessPage] auto login failed", error);
     }
   }, [
-    accessToken,
+    isAuthenticated,
     autoLoginCredential,
     loginMutation,
     setAuthenticated,

--- a/src/pages/room/model/useChatSearchStackPageModel.ts
+++ b/src/pages/room/model/useChatSearchStackPageModel.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 
 import { type ChatRoomSearchItemVM, useChatRoomSearchListQuery } from "@/entities/chat-room";
 import { useAuthStore } from "@/entities/user";
@@ -11,10 +11,7 @@ import {
   CHAT_SEARCH_SIZE,
   JOIN_CHAT_ROOM_USER_ID_REQUIRED_MESSAGE,
 } from "./chatSearch.constants";
-import {
-  getJoinChatRoomErrorMessage,
-  resolveParticipantIdFromAccessToken,
-} from "./chatSearch.utils";
+import { getJoinChatRoomErrorMessage } from "./chatSearch.utils";
 
 interface UseChatSearchStackPageModelOptions {
   onJoinSuccess: (room: ChatRoomSearchItemVM) => void;
@@ -24,11 +21,7 @@ export function useChatSearchStackPageModel({ onJoinSuccess }: UseChatSearchStac
   const [keyword, setKeyword] = useState("");
   const [selectedRoom, setSelectedRoom] = useState<ChatRoomSearchItemVM | null>(null);
   const [isJoinDialogOpen, setIsJoinDialogOpen] = useState(false);
-  const accessToken = useAuthStore((state) => state.accessToken);
-  const participantId = useMemo(
-    () => resolveParticipantIdFromAccessToken(accessToken),
-    [accessToken],
-  );
+  const participantId = useAuthStore((state) => state.userId ?? null);
   const joinChatRoomMutation = useJoinChatRoomMutation();
   const { showToast } = useToast();
 

--- a/src/shared/api/apiFetch.ts
+++ b/src/shared/api/apiFetch.ts
@@ -1,5 +1,10 @@
 import { ApiError } from "./error";
-import { getAccessToken } from "@/shared/auth";
+
+function getXsrfToken(): string | null {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie.match(/(?:^|;\s*)XSRF-TOKEN=([^;]*)/);
+  return match ? decodeURIComponent(match[1]) : null;
+}
 
 type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
 
@@ -37,10 +42,9 @@ export async function apiFetch<TResponse, TBody = unknown>(
     mergedHeaders.set("Content-Type", "application/json");
   }
 
-  const accessToken = getAccessToken();
-  if (accessToken && !mergedHeaders.has("Authorization")) {
-    const bearerToken = accessToken.startsWith("Bearer ") ? accessToken : `Bearer ${accessToken}`;
-    mergedHeaders.set("Authorization", bearerToken);
+  if (method !== "GET" && !mergedHeaders.has("X-XSRF-TOKEN")) {
+    const xsrfToken = getXsrfToken();
+    if (xsrfToken) mergedHeaders.set("X-XSRF-TOKEN", xsrfToken);
   }
 
   const res = await fetch(url, {

--- a/src/shared/auth/auth.handlers.ts
+++ b/src/shared/auth/auth.handlers.ts
@@ -4,57 +4,28 @@
  * 의존성 방향을 통제하는 중간 어댑터다.
  *
  * 그래서 configureAuthHandlers로 실제 구현(entities/user)을 주입하고,
- * shared 코드는 getAccessToken/clearAuth 같은 인터페이스만 사용한다.
+ * shared 코드는 clearAuth 같은 인터페이스만 사용한다.
  */
-import { clearTokenFromSession, saveTokenToSession } from "./token.storage";
 export type AuthHandlers = {
-  getAccessToken?: () => string | undefined;
-  setAuthenticated?: (token: string) => void;
+  setAuthenticated?: () => void;
   setUserId?: (userId: number) => void;
   clearAuth?: () => void;
 };
 
 let handlers: AuthHandlers = {};
 
-/**
- * 인증 핸들러 콜백을 등록/갱신한다.
- * shared 레이어가 entities/user 스토어에 직접 의존하지 않도록
- * 동작을 주입하는 역할이다.
- */
 export function configureAuthHandlers(next: AuthHandlers) {
   handlers = { ...handlers, ...next };
 }
 
-/**
- * 등록된 핸들러가 있으면 현재 액세스 토큰을 반환한다.
- * shared 코드가 entity 스토어를 import하지 않고
- * 인증 상태를 읽기 위한 간접 접근이다.
- */
-export function getAccessToken() {
-  return handlers.getAccessToken?.();
+export function setAuthenticated() {
+  handlers.setAuthenticated?.();
 }
 
-/**
- * 인증 성공 토큰을 등록된 핸들러로 전달한다.
- * 보통 refresh 이후 entity/user 스토어 갱신에 사용된다.
- */
-export function setAuthenticated(token: string) {
-  saveTokenToSession(token);
-  handlers.setAuthenticated?.(token);
-}
-
-/**
- * 소켓 handshake 등에서 확인한 userId를 전역 인증 스토어에 반영한다.
- */
 export function setAuthUserId(userId: number) {
   handlers.setUserId?.(userId);
 }
 
-/**
- * 등록된 핸들러를 통해 인증 상태를 초기화한다.
- * 로그아웃 또는 401 처리 시 user auth 상태 무효화에 사용된다.
- */
 export function clearAuth() {
-  clearTokenFromSession();
   handlers.clearAuth?.();
 }

--- a/src/shared/auth/auth.service.ts
+++ b/src/shared/auth/auth.service.ts
@@ -1,8 +1,12 @@
 import { ApiError, apiFetch, Endpoint } from "@/shared/api";
 import { clearAuth, setAuthenticated } from "./auth.handlers";
-import { getStoredFreshToken } from "./token.storage";
 
-let refreshPromise: Promise<string> | null = null;
+let refreshPromise: Promise<void> | null = null;
+let cachedDeviceId: string | null = null;
+
+export function getDeviceId(): string | null {
+  return cachedDeviceId;
+}
 
 function isUnauthorizedError(error: unknown) {
   if (error instanceof ApiError) return error.httpStatus === 401;
@@ -12,18 +16,33 @@ function isUnauthorizedError(error: unknown) {
   return false;
 }
 
+/**
+ * AT HttpOnly 쿠키가 유효한지 서버 사이드에서 확인한다.
+ * 유효하면 true, 만료/없으면 false.
+ */
+async function checkAuthCookie(): Promise<boolean> {
+  try {
+    const res = await fetch("/api/auth/session", { credentials: "include" });
+    if (!res.ok) return false;
+    const json = (await res.json()) as { deviceId?: string | null };
+    cachedDeviceId = json.deviceId ?? null;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export const AuthService = {
   async refresh() {
     if (!refreshPromise) {
       refreshPromise = (async () => {
         try {
-          const res = await apiFetch<{ accessToken: string }>(Endpoint.TOKEN.REFRESH, {
+          await apiFetch<unknown>(Endpoint.TOKEN.REFRESH, {
             method: "PUT",
             credentials: "include",
           });
-
-          setAuthenticated(res.accessToken);
-          return res.accessToken;
+          await checkAuthCookie();
+          setAuthenticated();
         } catch (e) {
           console.warn("[AuthService] refresh failed", e);
           clearAuth();
@@ -58,10 +77,14 @@ export const AuthService = {
     }
   },
 
-  restoreFromSession(): boolean {
-    const token = getStoredFreshToken();
-    if (!token) return false;
-    setAuthenticated(token);
+  /**
+   * 페이지 리로드 시 AT 쿠키가 아직 유효하면 refresh 없이 인증 상태를 복원한다.
+   * 유효하지 않으면 false를 반환하고 caller가 refresh()를 시도해야 한다.
+   */
+  async restoreFromCookie(): Promise<boolean> {
+    const ok = await checkAuthCookie();
+    if (!ok) return false;
+    setAuthenticated();
     return true;
   },
 

--- a/src/shared/auth/index.ts
+++ b/src/shared/auth/index.ts
@@ -1,11 +1,5 @@
-export { AuthService } from "./auth.service";
-export {
-  clearAuth,
-  configureAuthHandlers,
-  getAccessToken,
-  setAuthUserId,
-  setAuthenticated,
-} from "./auth.handlers";
+export { AuthService, getDeviceId } from "./auth.service";
+export { clearAuth, configureAuthHandlers, setAuthUserId, setAuthenticated } from "./auth.handlers";
 export {
   AUTH_DEFAULT_AUTHENTICATED_PATH,
   AUTH_LOGIN_PATH,

--- a/src/shared/socket/chatStompSession.ts
+++ b/src/shared/socket/chatStompSession.ts
@@ -3,7 +3,7 @@
 import { Client, type IFrame, type StompSubscription } from "@stomp/stompjs";
 
 import { ApiError, apiFetch, Endpoint } from "@/shared/api";
-import { AuthService, setAuthUserId } from "@/shared/auth";
+import { AuthService, getDeviceId, setAuthUserId } from "@/shared/auth";
 import {
   parseConnectedErrorCode,
   parseConnectedSuccessPayload,
@@ -60,7 +60,6 @@ import {
   chatSocketWarn,
   resolveStompDebugLogger,
 } from "./model/socketLogger";
-import { ensureBearerToken, resolveDeviceIdFromJwt } from "./model/token";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -413,7 +412,6 @@ function toUnreadChangedPayload(candidate: unknown): UnreadChangedUserEventPaylo
 class ChatStompSession {
   private client: Client | null = null;
   private config: ChatSocketStartConfig | null = null;
-  private lastBearerToken: string | null = null;
   private isRefreshing = false;
   private connectedUserId: number | null = null;
 
@@ -768,27 +766,25 @@ class ChatStompSession {
    * - 동일 토큰 중복 start 방지
    * - CONNECT → CONNECTED → SUBSCRIBE_USER 핸드셰이크 수행
    */
-  start(accessToken: string) {
+  start() {
     if (typeof window === "undefined") return;
 
     const startConfig = resolveChatSocketStartConfig();
     if (!startConfig) return;
 
-    const bearerToken = ensureBearerToken(accessToken);
-    const deviceId = resolveDeviceIdFromJwt(bearerToken);
+    const deviceId = getDeviceId();
     if (!deviceId) {
-      chatSocketWarn("[chat-socket] skip connect: JWT payload에 deviceId가 없습니다.");
+      chatSocketWarn("[chat-socket] skip connect: deviceId가 없습니다.");
       return;
     }
 
     chatSocketLog("[chat-socket] start requested", {
-      hasAccessToken: Boolean(accessToken),
       brokerURL: startConfig.brokerURL,
       isActive: this.client?.active ?? false,
     });
 
-    if (this.client && this.lastBearerToken === bearerToken) {
-      chatSocketLog("[chat-socket] start skipped: existing client with same token", {
+    if (this.client?.active) {
+      chatSocketLog("[chat-socket] start skipped: existing active client", {
         isActive: this.client.active,
         isConnected: this.client.connected,
       });
@@ -811,15 +807,12 @@ class ChatStompSession {
       reconnectDelay: startConfig.reconnectDelayMs,
       heartbeatIncoming: 10000,
       heartbeatOutgoing: 10000,
-      connectHeaders: {
-        accessToken: bearerToken,
-        deviceId,
-      },
+      connectHeaders: {},
       debug: resolveStompDebugLogger(),
     });
 
     client.onConnect = () => {
-      this.setupSubscriptions(client, startConfig, bearerToken, deviceId);
+      this.setupSubscriptions(client, startConfig, deviceId);
     };
 
     client.onStompError = (frame: IFrame) => {
@@ -849,7 +842,6 @@ class ChatStompSession {
     client.activate();
     chatSocketLog("[chat-socket] client.activate called");
     this.client = client;
-    this.lastBearerToken = bearerToken;
   }
 
   /*
@@ -938,7 +930,6 @@ class ChatStompSession {
 
     this.client = null;
     this.config = null;
-    this.lastBearerToken = null;
     this.connectedUserId = null;
   }
 
@@ -984,8 +975,7 @@ class ChatStompSession {
   private handleDuplicateSessionConflict(message: string, retryAfterMs?: number) {
     if (this.isDuplicateReconnectPending) return;
 
-    const retryToken = this.lastBearerToken;
-    if (!retryToken) {
+    if (!this.client) {
       this.stop({
         code: "CONNECT_DUPLICATE_SESSION",
         message: "중복 세션 재연결에 필요한 토큰이 없어 연결을 종료합니다.",
@@ -1020,7 +1010,7 @@ class ChatStompSession {
     this.duplicateReconnectTimer = window.setTimeout(() => {
       this.duplicateReconnectTimer = null;
       this.isDuplicateReconnectPending = false;
-      this.start(retryToken);
+      this.start();
     }, retryDelayMs);
   }
 
@@ -1316,12 +1306,7 @@ class ChatStompSession {
 
   // ─── Subscription setup (called on every onConnect) ──────────────────────────
 
-  private setupSubscriptions(
-    client: Client,
-    config: ChatSocketStartConfig,
-    bearerToken: string,
-    deviceId: string,
-  ) {
+  private setupSubscriptions(client: Client, config: ChatSocketStartConfig, deviceId: string) {
     // Clear refs from previous connection (already closed socket)
     this.handshakeSubscription = null;
     this.userQueueSubscription = null;
@@ -1336,7 +1321,7 @@ class ChatStompSession {
     // Publish socket.connect handshake
     client.publish({
       destination: config.connectDestination,
-      body: JSON.stringify({ accessToken: bearerToken, deviceId }),
+      body: JSON.stringify({ deviceId }),
     });
     chatSocketLog("[chat-socket] socket.connect published", {
       destination: config.connectDestination,
@@ -1424,8 +1409,7 @@ class ChatStompSession {
           this.clearScheduledRefreshReconnectTimer();
           this.scheduledRefreshReconnectTimer = window.setTimeout(() => {
             this.scheduledRefreshReconnectTimer = null;
-            if (!this.lastBearerToken) return;
-            this.start(this.lastBearerToken);
+            this.start();
           }, delay);
         }
         return;
@@ -1909,9 +1893,8 @@ class ChatStompSession {
     this.isRefreshing = true;
 
     try {
-      const nextToken = await AuthService.refresh();
-      // start() detects token change → calls stopClient(preserveRooms=true) → reconnects
-      this.start(nextToken);
+      await AuthService.refresh();
+      this.start();
     } catch (error) {
       chatSocketWarn("[chat-socket] refresh and reconnect failed", error);
       this.stop({

--- a/src/shared/socket/model/token.ts
+++ b/src/shared/socket/model/token.ts
@@ -2,6 +2,12 @@ export function ensureBearerToken(token: string) {
   return token.startsWith("Bearer ") ? token : `Bearer ${token}`;
 }
 
+export function resolveDeviceIdFromCookie(): string | null {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie.match(/(?:^|;\s*)deviceId=([^;]*)/);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
 function toRawAccessToken(token: string) {
   return token.startsWith("Bearer ") ? token.slice(7) : token;
 }


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- `develop` 최신 변경(쿠키 기반 인증 복원, 소켓 핸드셰이크 정리, XSRF 전달 경로 적용)을 `release/2.0.2`에 반영
- 포함 커밋
  - `feat(auth): 쿠키 기반 인증 복원 경로 전환 (#556)`
  - `refactor(socket): 디바이스 아이디 기반 소켓 핸드셰이크 경로 정리 (#556)`
  - `feat(bff): xsrf 토큰 전달 경로 적용 (#556)`

## 작업 배경/목적

- `release/2.0.2` 브랜치에 최신 `develop` 인증/소켓/BFF 보정 사항을 반영해 릴리즈 기준선을 맞추기 위함

## 영향 범위

- 인증 복원/재발급 경로
- 보호 라우트 인증 상태 판정
- 소켓 핸드셰이크 payload/연결 시작 흐름
- BFF 헤더 allowlist 및 API 요청 XSRF 전달

## 테스트/검증

- 포함 PR(#558) 기준 pre-commit `pnpm lint` 통과(기존 warning만 존재)
- 릴리즈 브랜치 반영 후 회귀 확인 필요 항목
  - 새로고침 인증 복원
  - refresh 후 보호 API 접근
  - 소켓 연결/핸드셰이크

## 성능 측정 (performance 작업 필수)

- 해당 없음 (performance 라벨/이슈 아님)

## 관련 이슈

- Refs #557
- Refs #556
- Refs #558

## 참고 문서/링크

- https://github.com/100-hours-a-week/7-team-temporary-fe/pull/558
- https://github.com/100-hours-a-week/7-team-temporary-fe/issues/557
- https://github.com/100-hours-a-week/7-team-temporary-fe/issues/556
