### PR TITLE
[auth-proxy #565] feat: retro SSR 도입

### DIFF
--- a/app/(protected)/retro/page.tsx
+++ b/app/(protected)/retro/page.tsx
@@ -1,5 +1,26 @@
-import { AppShellPage } from "@/pages/app-shell";
+import { QueryClient, dehydrate, HydrationBoundary } from "@tanstack/react-query";
 
-export default function RetroPage() {
-  return <AppShellPage />;
+import { AppShellPage } from "@/pages/app-shell";
+import { serverFetch, serverTaskPath } from "@/shared/api/serverFetch";
+import { retroQueryKeys } from "@/entities/retro";
+
+export default async function RetroPage() {
+  const queryClient = new QueryClient();
+
+  await Promise.allSettled([
+    queryClient.prefetchQuery({
+      queryKey: retroQueryKeys.myList(1, 10),
+      queryFn: () => serverFetch(serverTaskPath("/reflections/me?page=1&size=10")),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: retroQueryKeys.publicList(true, 1, 10),
+      queryFn: () => serverFetch(serverTaskPath("/reflections?isOpen=true&page=1&size=10")),
+    }),
+  ]);
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <AppShellPage />
+    </HydrationBoundary>
+  );
 }

--- a/src/shared/ui/image/HorizontalImageAlbum.tsx
+++ b/src/shared/ui/image/HorizontalImageAlbum.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useRef, type KeyboardEvent, type WheelEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, type KeyboardEvent } from "react";
 
 import { cn } from "@/shared/lib";
 
@@ -31,7 +31,7 @@ export function HorizontalImageAlbum({
   }, []);
 
   const handleWheel = useCallback(
-    (event: WheelEvent<HTMLDivElement>) => {
+    (event: WheelEvent) => {
       const element = scrollRef.current;
       if (!element) return;
       if (Math.abs(event.deltaY) < Math.abs(event.deltaX)) return;
@@ -51,6 +51,13 @@ export function HorizontalImageAlbum({
     },
     [scrollByOffset],
   );
+
+  useEffect(() => {
+    const element = scrollRef.current;
+    if (!element) return;
+    element.addEventListener("wheel", handleWheel, { passive: false });
+    return () => element.removeEventListener("wheel", handleWheel);
+  }, [handleWheel]);
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLDivElement>) => {
@@ -75,7 +82,6 @@ export function HorizontalImageAlbum({
       role="region"
       aria-label={scrollAreaLabel}
       tabIndex={enableKeyboardScroll ? 0 : -1}
-      onWheel={handleWheel}
       onKeyDown={handleKeyDown}
       className={cn(
         "scrollbar-hide touch-pan-x overflow-x-auto overflow-y-hidden overscroll-x-contain",


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- `/retro` 페이지에 SSR prefetch + hydration 경로를 추가했다.
- `HorizontalImageAlbum`의 wheel 스크롤 핸들러를 native 이벤트 등록 방식으로 보완했다.

## 작업 배경/목적

- BFF 에픽 하위 Task(#565)로 retro 탭 초기 조회를 SSR 경로로 전환하기 위함.

## 영향 범위

- retro 초기 데이터 로딩 경로
- 공통 이미지 앨범의 가로 스크롤 이벤트 처리

## 테스트/검증

- `pnpm lint` (pre-commit hook) 통과

## 성능 측정 (performance 작업 필수)

- 해당 없음 (performance 라벨/작업 아님)

## 관련 이슈

- Closes #565

## 참고 문서/링크

- https://github.com/100-hours-a-week/7-team-temporary-fe/issues/565
