### PR TITLE
[thin-bff-foundation #568] refactor: 훅/스토어 use client 경계 정리

### DIFF
--- a/src/entities/cam-study-room/model/useCamStudyRoomListQuery.ts
+++ b/src/entities/cam-study-room/model/useCamStudyRoomListQuery.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useQuery } from "@tanstack/react-query";
 
 import { fetchCamStudyRoomList } from "../api";

--- a/src/entities/cam-study-room/model/useLiveKitSession.ts
+++ b/src/entities/cam-study-room/model/useLiveKitSession.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useCallback, useEffect, useRef, useState } from "react";
 
 const VIDEO_HEARTBEAT_INTERVAL_MS = 15_000;

--- a/src/entities/chat-room/model/useChatRoomDetailQuery.ts
+++ b/src/entities/chat-room/model/useChatRoomDetailQuery.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useQuery } from "@tanstack/react-query";
 
 import { fetchChatRoomDetail } from "../api";

--- a/src/entities/chat-room/model/useChatRoomMessagesInfiniteQuery.ts
+++ b/src/entities/chat-room/model/useChatRoomMessagesInfiniteQuery.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useCallback, useMemo } from "react";
 
 import { useCursorInfiniteQuery } from "@/shared/query";

--- a/src/entities/chat-room/model/useChatRoomMessagesQuery.ts
+++ b/src/entities/chat-room/model/useChatRoomMessagesQuery.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useQuery } from "@tanstack/react-query";
 
 import { fetchChatRoomMessages } from "../api";

--- a/src/entities/chat-room/model/useChatRoomOwnerStatusQuery.ts
+++ b/src/entities/chat-room/model/useChatRoomOwnerStatusQuery.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useQuery } from "@tanstack/react-query";
 
 import { fetchChatRoomOwnerStatus } from "../api";

--- a/src/entities/chat-room/model/useChatRoomRealtimeMock.ts
+++ b/src/entities/chat-room/model/useChatRoomRealtimeMock.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useMemo, useState } from "react";
 
 import {

--- a/src/entities/chat-room/model/useChatRoomSearchListQuery.ts
+++ b/src/entities/chat-room/model/useChatRoomSearchListQuery.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useQuery } from "@tanstack/react-query";
 
 import { fetchChatRoomSearchList } from "../api";

--- a/src/entities/chat-room/model/useGroupChatRoomListQuery.ts
+++ b/src/entities/chat-room/model/useGroupChatRoomListQuery.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useQuery } from "@tanstack/react-query";
 
 import { fetchChatRoomList } from "../api";

--- a/src/entities/day-plan-presence/model/useDayPlanPeriodSchedulesQuery.ts
+++ b/src/entities/day-plan-presence/model/useDayPlanPeriodSchedulesQuery.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useQuery } from "@tanstack/react-query";
 
 import { fetchDayPlanPeriodSchedules } from "../api";

--- a/src/entities/day-plan-schedule/model/useCurrentScheduleQuery.ts
+++ b/src/entities/day-plan-schedule/model/useCurrentScheduleQuery.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useQuery } from "@tanstack/react-query";
 
 import { fetchCurrentSchedule } from "../api";

--- a/src/entities/day-plan-schedule/model/useDayPlanScheduleByIdQuery.ts
+++ b/src/entities/day-plan-schedule/model/useDayPlanScheduleByIdQuery.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useQuery } from "@tanstack/react-query";
 
 import { fetchDayPlanScheduleById } from "../api";

--- a/src/entities/day-plan-schedule/model/useDayPlanScheduleQuery.ts
+++ b/src/entities/day-plan-schedule/model/useDayPlanScheduleQuery.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useQuery } from "@tanstack/react-query";
 
 import { fetchDayPlanSchedule } from "../api";

--- a/src/entities/day-plan-schedule/model/useDayPlanSchedulesQuery.ts
+++ b/src/entities/day-plan-schedule/model/useDayPlanSchedulesQuery.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useQuery } from "@tanstack/react-query";
 
 import { fetchDayPlanSchedules } from "../api";

--- a/src/entities/day-plan/model/useDayPlanId.ts
+++ b/src/entities/day-plan/model/useDayPlanId.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useDayPlanScheduleQuery } from "@/entities/day-plan-schedule";
 
 interface UseDayPlanIdOptions {

--- a/src/entities/day-plan/model/useDayPlanReflectionStatusQuery.ts
+++ b/src/entities/day-plan/model/useDayPlanReflectionStatusQuery.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useQuery } from "@tanstack/react-query";
 
 import { fetchDayPlanReflectionStatus } from "../api";

--- a/src/entities/friend/model/useAcceptFriendRequestMutation.ts
+++ b/src/entities/friend/model/useAcceptFriendRequestMutation.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import type { UseMutationOptions } from "@tanstack/react-query";
 import { useMutation } from "@tanstack/react-query";
 

--- a/src/entities/friend/model/useCreateFriendRequestMutation.ts
+++ b/src/entities/friend/model/useCreateFriendRequestMutation.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import type { UseMutationOptions } from "@tanstack/react-query";
 import { useMutation } from "@tanstack/react-query";
 

--- a/src/entities/friend/model/useDeleteFriendMutation.ts
+++ b/src/entities/friend/model/useDeleteFriendMutation.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import type { UseMutationOptions } from "@tanstack/react-query";
 import { useMutation } from "@tanstack/react-query";
 

--- a/src/entities/friend/model/useDeleteFriendRequestMutation.ts
+++ b/src/entities/friend/model/useDeleteFriendRequestMutation.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import type { UseMutationOptions } from "@tanstack/react-query";
 import { useMutation } from "@tanstack/react-query";
 

--- a/src/entities/friend/model/useFriendRequestsQuery.ts
+++ b/src/entities/friend/model/useFriendRequestsQuery.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useQuery } from "@tanstack/react-query";
 
 import { fetchFriendRequests } from "../api";

--- a/src/entities/friend/model/useFriendSearchQuery.ts
+++ b/src/entities/friend/model/useFriendSearchQuery.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useQuery } from "@tanstack/react-query";
 
 import { fetchFriendSearchByNickname } from "../api";

--- a/src/entities/friend/model/useFriendsQuery.ts
+++ b/src/entities/friend/model/useFriendsQuery.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useQuery } from "@tanstack/react-query";
 
 import { fetchFriends } from "../api";

--- a/src/entities/notification/model/useNotificationsQuery.ts
+++ b/src/entities/notification/model/useNotificationsQuery.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useQuery } from "@tanstack/react-query";
 
 import { fetchNotifications } from "../api";

--- a/src/entities/report/model/useReportMessagesInfiniteQuery.ts
+++ b/src/entities/report/model/useReportMessagesInfiniteQuery.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useCallback, useMemo } from "react";
 
 import { useCursorInfiniteQuery } from "@/shared/query";

--- a/src/entities/report/model/useWeeklyReportQuery.ts
+++ b/src/entities/report/model/useWeeklyReportQuery.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useQuery } from "@tanstack/react-query";
 
 import { fetchWeeklyReport } from "../api";

--- a/src/entities/retro/model/useMyRetrosQuery.ts
+++ b/src/entities/retro/model/useMyRetrosQuery.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useQuery } from "@tanstack/react-query";
 
 import { fetchMyRetros } from "../api";

--- a/src/entities/retro/model/usePublicRetroByIdQuery.ts
+++ b/src/entities/retro/model/usePublicRetroByIdQuery.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useQuery } from "@tanstack/react-query";
 
 import { fetchPublicRetroById } from "../api";

--- a/src/entities/retro/model/usePublicRetrosQuery.ts
+++ b/src/entities/retro/model/usePublicRetrosQuery.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useQuery } from "@tanstack/react-query";
 
 import { fetchPublicRetros } from "../api";

--- a/src/entities/retro/model/useRetroDeleteMutation.ts
+++ b/src/entities/retro/model/useRetroDeleteMutation.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { deleteRetro } from "../api";

--- a/src/entities/retro/model/useRetroLikeMutation.ts
+++ b/src/entities/retro/model/useRetroLikeMutation.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import type { MyRetroListResponseDto } from "../api";

--- a/src/entities/user/model/useDeleteMyProfileMutation.ts
+++ b/src/entities/user/model/useDeleteMyProfileMutation.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import type { UseMutationOptions } from "@tanstack/react-query";
 import { useMutation } from "@tanstack/react-query";
 

--- a/src/entities/user/model/useMyProfileQuery.ts
+++ b/src/entities/user/model/useMyProfileQuery.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 

--- a/src/entities/user/model/useUpdateMyProfileImageMutation.ts
+++ b/src/entities/user/model/useUpdateMyProfileImageMutation.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useOptimisticMutation } from "@/shared/query";
 
 import { updateMyProfileImage } from "../api";

--- a/src/entities/user/model/useUpdateMyProfileMutation.ts
+++ b/src/entities/user/model/useUpdateMyProfileMutation.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useOptimisticMutation } from "@/shared/query";
 
 import { updateMyProfile } from "../api";

--- a/src/entities/user/model/useUpdatePasswordMutation.ts
+++ b/src/entities/user/model/useUpdatePasswordMutation.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import type { UseMutationOptions } from "@tanstack/react-query";
 import { useMutation } from "@tanstack/react-query";
 

--- a/src/entities/user/model/userPreferences.store.ts
+++ b/src/entities/user/model/userPreferences.store.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { create } from "zustand";
 
 import type { UserDayEndTime, UserFocusTimeZone } from "./types";


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- Query/Mutation/Store 훅 37개 파일 상단에 `"use client"` 지시문을 추가해 클라이언트 경계를 명시했습니다.
- XSRF/SSR 기능 변경은 제외하고, `use client` 경계 정리만 분리 커밋했습니다.

## 작업 배경/목적

- BFF/SSR 전환 과정에서 훅 파일이 Server Component 컨텍스트로 해석될 수 있는 위험을 제거하기 위함입니다.
- 이슈 #568 범위에 맞춰 클라이언트 전용 훅/스토어 실행 경계를 명확히 고정했습니다.

## 영향 범위

- `src/entities/*/model` 하위 Query/Mutation 훅
- `src/entities/user/model/userPreferences.store.ts`
- 동작 로직 변경 없이 파일 경계(`"use client"`)만 추가

## 테스트/검증

- `cat /tmp/issue-568-use-client-files.txt | xargs pnpm -s exec eslint`
- 결과: 통과

## 성능 측정 (performance 작업 필수)

- 해당 없음 (performance 라벨/범위 작업 아님)

## 관련 이슈

- Closes #568

## 참고 문서/링크

- 이슈: https://github.com/100-hours-a-week/7-team-temporary-fe/issues/568
