### PR TITLE
[chat-api #575] fix: 채팅 소켓 연결 XSRF 처리 보강

### DIFF
--- a/src/shared/api/apiFetch.ts
+++ b/src/shared/api/apiFetch.ts
@@ -1,6 +1,6 @@
 import { ApiError } from "./error";
 
-function getXsrfToken(): string | null {
+export function getXsrfToken(): string | null {
   if (typeof document === "undefined") return null;
   const match = document.cookie.match(/(?:^|;\s*)XSRF-TOKEN=([^;]*)/);
   return match ? decodeURIComponent(match[1]) : null;
@@ -32,6 +32,7 @@ type ApiResponse<T> = {
 export async function apiFetch<TResponse, TBody = unknown>(
   url: string,
   options: FetchOptions<TBody> = {},
+  _csrfRetry = true,
 ): Promise<TResponse> {
   const { method = "GET", body, headers, signal, authRequired } = options;
   const { credentials } = options;
@@ -57,6 +58,14 @@ export async function apiFetch<TResponse, TBody = unknown>(
 
   if (res.status === 204) {
     return undefined as TResponse;
+  }
+
+  // 403 + non-GET: 서버가 새 XSRF-TOKEN을 발급했을 수 있으므로 한 번만 retry
+  if (res.status === 403 && method !== "GET" && _csrfRetry) {
+    const newToken = getXsrfToken();
+    if (newToken) {
+      return apiFetch(url, options, false);
+    }
   }
 
   const text = await res.text();

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -1,4 +1,4 @@
-export { apiFetch } from "./apiFetch";
+export { apiFetch, getXsrfToken } from "./apiFetch";
 export { ApiError } from "./error";
 export type { UiError } from "./error";
 export { Endpoint } from "./endpoints";

--- a/src/shared/socket/chatStompSession.ts
+++ b/src/shared/socket/chatStompSession.ts
@@ -2,7 +2,7 @@
 
 import { Client, type IFrame, type StompSubscription } from "@stomp/stompjs";
 
-import { ApiError, apiFetch, Endpoint } from "@/shared/api";
+import { ApiError, apiFetch, Endpoint, getXsrfToken } from "@/shared/api";
 import { AuthService, getDeviceId, setAuthUserId } from "@/shared/auth";
 import {
   parseConnectedErrorCode,
@@ -807,7 +807,7 @@ class ChatStompSession {
       reconnectDelay: startConfig.reconnectDelayMs,
       heartbeatIncoming: 10000,
       heartbeatOutgoing: 10000,
-      connectHeaders: { deviceId: deviceId ?? "" },
+      connectHeaders: { deviceId: deviceId ?? "", "X-XSRF-TOKEN": getXsrfToken() ?? "" },
       debug: resolveStompDebugLogger(),
     });
 


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- STOMP CONNECT 헤더에 `X-XSRF-TOKEN`을 포함하도록 보강
- `apiFetch`의 XSRF 토큰 조회 함수를 외부에서 재사용 가능하도록 export
- non-GET 요청이 403일 때 XSRF 토큰 기준 1회 재시도 로직 추가

## 작업 배경/목적

- 채팅방 진입 시 웹소켓 연결이 실패하는 이슈(#575)에서, 핸드셰이크/연결 구간의 XSRF 전달 누락 가능성을 줄이고 연결 안정성을 높이기 위함

## 영향 범위

- 채팅 소켓 연결 초기화(`chatStompSession`)
- 공통 API fetch 유틸(`apiFetch`)
- shared API export 표면(`index.ts`)

## 테스트/검증

- `pnpm -s exec tsc --noEmit --pretty false` 통과
- 코드 경로 점검:
  - 소켓 CONNECT 헤더에 `X-XSRF-TOKEN` 주입
  - 403(non-GET) 응답 시 최대 1회 재시도

## 성능 측정 (performance 작업 필수)

- 해당 없음 (performance 라벨/작업 아님)

## 관련 이슈

- Closes #575

## 참고 문서/링크

- 
