### PR TITLE
release(2.0.2): 최신 develop 변경 반영

### DIFF
--- a/src/shared/api/apiFetch.ts
+++ b/src/shared/api/apiFetch.ts
@@ -1,6 +1,6 @@
 import { ApiError } from "./error";
 
-function getXsrfToken(): string | null {
+export function getXsrfToken(): string | null {
   if (typeof document === "undefined") return null;
   const match = document.cookie.match(/(?:^|;\s*)XSRF-TOKEN=([^;]*)/);
   return match ? decodeURIComponent(match[1]) : null;
@@ -32,6 +32,7 @@ type ApiResponse<T> = {
 export async function apiFetch<TResponse, TBody = unknown>(
   url: string,
   options: FetchOptions<TBody> = {},
+  _csrfRetry = true,
 ): Promise<TResponse> {
   const { method = "GET", body, headers, signal, authRequired } = options;
   const { credentials } = options;
@@ -57,6 +58,14 @@ export async function apiFetch<TResponse, TBody = unknown>(
 
   if (res.status === 204) {
     return undefined as TResponse;
+  }
+
+  // 403 + non-GET: 서버가 새 XSRF-TOKEN을 발급했을 수 있으므로 한 번만 retry
+  if (res.status === 403 && method !== "GET" && _csrfRetry) {
+    const newToken = getXsrfToken();
+    if (newToken) {
+      return apiFetch(url, options, false);
+    }
   }
 
   const text = await res.text();

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -1,4 +1,4 @@
-export { apiFetch } from "./apiFetch";
+export { apiFetch, getXsrfToken } from "./apiFetch";
 export { ApiError } from "./error";
 export type { UiError } from "./error";
 export { Endpoint } from "./endpoints";

--- a/src/shared/socket/chatStompSession.ts
+++ b/src/shared/socket/chatStompSession.ts
@@ -2,7 +2,7 @@
 
 import { Client, type IFrame, type StompSubscription } from "@stomp/stompjs";
 
-import { ApiError, apiFetch, Endpoint } from "@/shared/api";
+import { ApiError, apiFetch, Endpoint, getXsrfToken } from "@/shared/api";
 import { AuthService, getDeviceId, setAuthUserId } from "@/shared/auth";
 import {
   parseConnectedErrorCode,
@@ -807,7 +807,7 @@ class ChatStompSession {
       reconnectDelay: startConfig.reconnectDelayMs,
       heartbeatIncoming: 10000,
       heartbeatOutgoing: 10000,
-      connectHeaders: { deviceId: deviceId ?? "" },
+      connectHeaders: { deviceId: deviceId ?? "", "X-XSRF-TOKEN": getXsrfToken() ?? "" },
       debug: resolveStompDebugLogger(),
     });
 


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- `develop` 최신 변경사항을 `release/2.0.2`로 동기화합니다.

## 포함 커밋

- `68cc631` Merge pull request #576 from 100-hours-a-week/fix/chat-api-575
- `50b8dd9` fix(chat-api): STOMP 연결 XSRF 토큰 처리 보강 (#575)

## 작업 배경/목적

- `release/2.0.2` 배포 브랜치에 `develop` 최신 수정사항 반영

## 영향 범위

- 채팅 소켓(STOMP) 연결 시 XSRF 토큰 처리 로직

## 테스트/검증

- develop 기준 선행 PR 검증 결과 재사용
- 브랜치 간 diff 확인: `origin/release/2.0.2..origin/develop`

## 관련 이슈

- N/A (release sync PR)

## 참고 문서/링크

- 이전 동기화 PR: #573
