### PR TITLE
[chat-api #578] fix: 소켓 토큰 만료/unauthorized 재연결 보정

### DIFF
--- a/app/api/socket-token/route.ts
+++ b/app/api/socket-token/route.ts
@@ -2,15 +2,33 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
 /**
- * AT + XSRF-TOKEN 쿠키가 모두 존재하는지 확인한다.
- * XSRF-TOKEN이 없으면 401을 반환해 caller(AuthService)가 refresh()를 실행하도록 유도한다.
- * refresh(PUT /token) 응답이 XSRF-TOKEN을 세팅하며, 이후 _lib.ts의 clearing 필터가
- * GET 응답에 의한 XSRF-TOKEN 삭제를 차단하여 토큰이 유지된다.
+ * AT + XSRF-TOKEN 쿠키가 모두 존재하고 AT가 만료되지 않았는지 확인한다.
+ * AT가 없거나 만료됐으면 401을 반환해 caller(AuthService)가 refresh()를 실행하도록 유도한다.
+ * XSRF-TOKEN이 없으면 401을 반환해 refresh()가 새 토큰을 세팅하도록 유도한다.
  */
+
+function isAccessTokenExpired(token: string): boolean {
+  try {
+    const payload = token.split(".")[1];
+    if (!payload) return true;
+    const decoded = JSON.parse(Buffer.from(payload, "base64").toString("utf-8")) as {
+      exp?: number;
+    };
+    if (typeof decoded.exp !== "number") return true;
+    return decoded.exp * 1000 < Date.now();
+  } catch {
+    return true;
+  }
+}
+
 export async function GET(req: NextRequest) {
   const accessToken = req.cookies.get("accessToken")?.value;
   if (!accessToken) {
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  if (isAccessTokenExpired(accessToken)) {
+    return NextResponse.json({ error: "token_expired" }, { status: 401 });
   }
 
   const xsrfToken = req.cookies.get("XSRF-TOKEN")?.value;

--- a/src/shared/socket/chatStompSession.ts
+++ b/src/shared/socket/chatStompSession.ts
@@ -1447,7 +1447,7 @@ class ChatStompSession {
         const retryAfterMs =
           typeof errorPayload?.retryAfterMs === "number" ? errorPayload.retryAfterMs : undefined;
 
-        if (code === "CONNECT_TOKEN_EXPIRED") {
+        if (code === "CONNECT_TOKEN_EXPIRED" || code === "CONNECT_UNAUTHORIZED") {
           this.scheduleRefreshReconnect(retryAfterMs ?? 0);
           return;
         }


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- `/api/socket-token`에서 accessToken 만료 여부를 함께 검증하도록 보강
- 만료/인증 실패 시 401 응답(`token_expired`)을 반환해 refresh 경로를 명확화
- 소켓 handshake 이벤트에서 `CONNECT_UNAUTHORIZED`도 refresh 재연결 분기로 처리

## 작업 배경/목적

- 웹소켓 handshake 쿠키/XSRF 누락 및 토큰 만료 케이스에서 연결이 끊기는 이슈(#578)를 안정적으로 복구하기 위함

## 영향 범위

- `app/api/socket-token/route.ts`
- `src/shared/socket/chatStompSession.ts`

## 테스트/검증

- `pnpm -s exec tsc --noEmit --pretty false` 통과
- 소켓 handshake 분기 확인:
  - `CONNECT_TOKEN_EXPIRED` -> refresh/reconnect
  - `CONNECT_UNAUTHORIZED` -> refresh/reconnect

## 성능 측정 (performance 작업 필수)

- 해당 없음 (performance 라벨/작업 아님)

## 관련 이슈

- Closes #578

## 참고 문서/링크

- 
