### PR TITLE
[cam-study-room #587] feat: STOMP 온라인 이벤트 기반 참가자 UI 동기화

### DIFF
--- a/src/pages/room/model/useCamStudyRoomStackPageModel.ts
+++ b/src/pages/room/model/useCamStudyRoomStackPageModel.ts
@@ -91,43 +91,42 @@ export function useCamStudyRoomStackPageModel({
         signal: controller.signal,
       });
 
-      if (onlineRes.participants.length > 0) {
-        setParticipants(
-          onlineRes.participants.map((p) => ({
-            userId: p.userId,
-            participantId: p.participantId,
-            nickname: p.nickname,
-            cameraEnabled: p.cameraEnabled,
-            screenVisible: p.cameraEnabled,
-            isMe: p.userId === resolvedUserId,
-            profileImageUrl: null,
-            joinedAt: p.onlineAt,
-            role:
-              p.userId === detailRes.owner.userId ? ("OWNER" as const) : ("PARTICIPANT" as const),
-          })),
-        );
-      } else {
-        // 온라인 참가자 없으면 나 자신만 표시
+      const onlineList = onlineRes.participants.map((p) => ({
+        userId: p.userId,
+        participantId: p.participantId,
+        nickname: p.nickname,
+        cameraEnabled: p.cameraEnabled,
+        screenVisible: p.cameraEnabled,
+        isMe: p.userId === resolvedUserId,
+        profileImageUrl: null,
+        joinedAt: p.onlineAt,
+        role: p.userId === detailRes.owner.userId ? ("OWNER" as const) : ("PARTICIPANT" as const),
+      }));
+
+      // Redis online 목록에 내가 없으면 직접 추가한다.
+      // (online 이벤트는 LiveKit 연결 후 전송되므로 GET 시점에 나는 목록에 없을 수 있다.)
+      const isMeInList = onlineList.some((p) => p.userId === resolvedUserId);
+      if (!isMeInList) {
         const isOwner = detailRes.owner.userId === resolvedUserId;
         const myEntry = isOwner
           ? detailRes.owner
           : detailRes.participants.find((p) => p.userId === resolvedUserId);
         if (myEntry) {
-          setParticipants([
-            {
-              userId: resolvedUserId,
-              participantId: resolvedParticipantId,
-              nickname: myEntry.nickname,
-              cameraEnabled: myEntry.cameraEnabled,
-              screenVisible: myEntry.cameraEnabled,
-              isMe: true,
-              profileImageUrl: null,
-              joinedAt: "joinedAt" in myEntry ? (myEntry.joinedAt as string) : "",
-              role: isOwner ? ("OWNER" as const) : ("PARTICIPANT" as const),
-            },
-          ]);
+          onlineList.push({
+            userId: resolvedUserId,
+            participantId: resolvedParticipantId,
+            nickname: myEntry.nickname,
+            cameraEnabled: myEntry.cameraEnabled,
+            screenVisible: myEntry.cameraEnabled,
+            isMe: true,
+            profileImageUrl: null,
+            joinedAt: "joinedAt" in myEntry ? (myEntry.joinedAt as string) : "",
+            role: isOwner ? ("OWNER" as const) : ("PARTICIPANT" as const),
+          });
         }
       }
+
+      setParticipants(onlineList);
 
       setParticipantId(resolvedParticipantId);
 
@@ -172,6 +171,32 @@ export function useCamStudyRoomStackPageModel({
     const unsubscribeRoom = chatStompSession.subscribeToRoom({
       roomId,
       participantId,
+      onVideoParticipantOnlined: ({
+        userId,
+        participantId: onlinedParticipantId,
+        nickname,
+        cameraEnabled,
+        at,
+      }) => {
+        setParticipants((prev) => {
+          if (prev.some((p) => p.userId === userId)) return prev;
+          return [
+            ...prev,
+            {
+              userId,
+              participantId: onlinedParticipantId,
+              nickname,
+              cameraEnabled,
+              screenVisible: cameraEnabled,
+              isMe: userId === myUserIdRef.current || onlinedParticipantId === participantId,
+              profileImageUrl: null,
+              joinedAt: at,
+              role:
+                userId === ownerUserIdRef.current ? ("OWNER" as const) : ("PARTICIPANT" as const),
+            },
+          ];
+        });
+      },
       onVideoCameraChanged: ({ userId, cameraEnabled }) => {
         setParticipants((prev) =>
           prev.map((p) =>

--- a/src/shared/socket/chatStompSession.ts
+++ b/src/shared/socket/chatStompSession.ts
@@ -38,6 +38,7 @@ import type {
   UnsubscribeRoomRequestPayload,
   VideoCameraChangedPayload,
   VideoCameraToggleAcceptedPayload,
+  VideoParticipantOnlinedPayload,
   VideoParticipantJoinedPayload,
   VideoParticipantLeftPayload,
   VideoPublishStartedPayload,
@@ -124,6 +125,7 @@ export interface SubscribeToRoomParams {
   onVideoCameraChanged?: (payload: VideoCameraChangedPayload) => void;
   onVideoPublishStarted?: (payload: VideoPublishStartedPayload) => void;
   onVideoPublishStopped?: (payload: VideoPublishStoppedPayload) => void;
+  onVideoParticipantOnlined?: (payload: VideoParticipantOnlinedPayload) => void;
   onVideoParticipantJoined?: (payload: VideoParticipantJoinedPayload) => void;
   onVideoParticipantLeft?: (payload: VideoParticipantLeftPayload) => void;
   onVideoRoomDeleted?: (payload: VideoRoomDeletedPayload) => void;
@@ -138,6 +140,7 @@ interface ActiveRoomEntry {
   onVideoCameraChanged?: (payload: VideoCameraChangedPayload) => void;
   onVideoPublishStarted?: (payload: VideoPublishStartedPayload) => void;
   onVideoPublishStopped?: (payload: VideoPublishStoppedPayload) => void;
+  onVideoParticipantOnlined?: (payload: VideoParticipantOnlinedPayload) => void;
   onVideoParticipantJoined?: (payload: VideoParticipantJoinedPayload) => void;
   onVideoParticipantLeft?: (payload: VideoParticipantLeftPayload) => void;
   onVideoRoomDeleted?: (payload: VideoRoomDeletedPayload) => void;
@@ -1814,6 +1817,12 @@ class ChatStompSession {
       if (event === "video.publish.stopped") {
         chatSocketLog("[chat-socket] video.publish.stopped", { roomId });
         entry.onVideoPublishStopped?.(payload as VideoPublishStoppedPayload);
+        return;
+      }
+
+      if (event === "video.participant.online") {
+        chatSocketLog("[chat-socket] video.participant.online", { roomId });
+        entry.onVideoParticipantOnlined?.(payload as VideoParticipantOnlinedPayload);
         return;
       }
 

--- a/src/shared/socket/model/handshake.types.ts
+++ b/src/shared/socket/model/handshake.types.ts
@@ -203,6 +203,17 @@ export interface VideoParticipantOfflinePayload {
 
 // ─── Video: Room broadcast (/sub/room/{roomId}) ───────────────────────────────
 
+export interface VideoParticipantOnlinedPayload {
+  eventId: string;
+  roomId: number;
+  participantId: number;
+  userId: number;
+  nickname: string;
+  sessionId: string;
+  cameraEnabled: boolean;
+  at: string;
+}
+
 export interface VideoParticipantJoinedPayload {
   eventId: string;
   roomId: number;


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- 캠 스터디 방 초기 진입 시 온라인 참가자 목록 구성 로직을 정리했다.
- STOMP `video.participant.online` 이벤트 핸들러를 추가해 온라인 참가자 UI를 즉시 반영하도록 연결했다.
- REST 온라인 조회 결과와 본인 참가자 정보를 병합해 초기 진입 누락 케이스를 보정했다.

## 작업 배경/목적

- 방 입장 직후 본인/타인 온라인 상태가 순서 이슈로 늦게 반영되거나 누락되는 문제를 줄이기 위함.
- STOMP 실시간 이벤트와 초기 REST 조회 간 정합성을 맞추기 위함.

## 영향 범위

- 캠 스터디 방 참가자 목록 초기화 및 실시간 반영 로직
- STOMP room 이벤트 타입/콜백 인터페이스

## 테스트/검증

- 로컬 lint 훅 통과(기존 경고만 존재)
- 방 진입 시 온라인 목록 노출 및 online 이벤트 수신 시 참가자 추가 동작 확인

## 성능 측정 (performance 작업 필수)

- 해당 없음 (performance 라벨/작업 아님)
- 측정 환경: N/A
- 측정 경로(URL): N/A

| 항목 | 변경 전 | 변경 후 | 변화량(Δ) |
|---|---:|---:|---:|
| Performance Score | N/A | N/A | N/A |
| FCP | N/A | N/A | N/A |
| LCP | N/A | N/A | N/A |
| TBT | N/A | N/A | N/A |
| CLS | N/A | N/A | N/A |
| Speed Index | N/A | N/A | N/A |

## 관련 이슈

- Closes #587

## 참고 문서/링크

- 없음
