### PR TITLE
[cam-study-room #590] fix: 캠 스터디 화면 미노출 진단/트랙 키 보정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -13,7 +13,7 @@ const nextConfig: NextConfig = {
 
   compiler: {
     emotion: true,
-    removeConsole: true,
+    removeConsole: false,
   },
 
   webpack(config) {

--- a/src/pages/room/ui/CamStudyParticipantGrid.tsx
+++ b/src/pages/room/ui/CamStudyParticipantGrid.tsx
@@ -59,9 +59,8 @@ function ParticipantCell({
     );
   }
 
-  const track = participant.isMe
-    ? localVideoTrack
-    : (remoteVideoTracks.get(String(participant.participantId ?? participant.userId)) ?? null);
+  const lookupKey = `user:${participant.userId}:participant:${participant.participantId}`;
+  const track = participant.isMe ? localVideoTrack : (remoteVideoTracks.get(lookupKey) ?? null);
 
   return (
     <div

--- a/src/shared/socket/model/socketEnv.ts
+++ b/src/shared/socket/model/socketEnv.ts
@@ -30,7 +30,7 @@ const VIDEO_PARTICIPANT_OFFLINE_DESTINATION =
   process.env.NEXT_PUBLIC_CHAT_SOCKET_VIDEO_PARTICIPANT_OFFLINE_DEST?.trim() ??
   "/pub/room/video/offline";
 const RECONNECT_DELAY_MS = Number(process.env.NEXT_PUBLIC_CHAT_SOCKET_RECONNECT_DELAY_MS ?? 5000);
-const CHAT_SOCKET_LOG_ENABLED = false;
+const CHAT_SOCKET_LOG_ENABLED = true;
 
 export interface ChatSocketStartConfig {
   brokerURL: string;


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- 캠 스터디 화면 미노출 재현 대응을 위해 콘솔 로그 제거 설정을 해제했다.
- 소켓 로그 게이트를 열어 STOMP 이벤트 흐름을 콘솔에서 확인 가능하게 했다.
- 참가자 그리드에서 원격 트랙 조회 키를 서버 식별 규칙(`user:{userId}:participant:{participantId}`)으로 보정했다.

## 작업 배경/목적

- 방 입장 후 화면이 비어 보이는 현상을 재현/진단하고 원인을 빠르게 특정하기 위함.
- 트랙 매핑 키 불일치로 인한 원격 비디오 미노출 가능성을 줄이기 위함.

## 영향 범위

- `next.config.ts` 콘솔 제거 설정
- `socketEnv.ts` 소켓 로그 출력 플래그
- `CamStudyParticipantGrid.tsx` 원격 트랙 조회 로직

## 테스트/검증

- `next lint` 훅 통과(기존 전역 경고만 존재)
- 캠 스터디 방 입장 시 콘솔에서 소켓 이벤트 흐름 확인
- 원격 참가자 트랙 조회 키가 서버 식별자 규칙과 일치하는지 확인

## 성능 측정 (performance 작업 필수)

- 해당 없음 (performance 라벨/작업 아님)
- 측정 환경: N/A
- 측정 경로(URL): N/A

| 항목 | 변경 전 | 변경 후 | 변화량(Δ) |
|---|---:|---:|---:|
| Performance Score | N/A | N/A | N/A |
| FCP | N/A | N/A | N/A |
| LCP | N/A | N/A | N/A |
| TBT | N/A | N/A | N/A |
| CLS | N/A | N/A | N/A |
| Speed Index | N/A | N/A | N/A |

## 관련 이슈

- Closes #590

## 참고 문서/링크

- 없음
