### PR TITLE
[cam-study-room #592] fix: 방 퇴장 SUB 오프라인 이벤트 UI 반영

### DIFF
--- a/src/pages/room/model/useCamStudyRoomStackPageModel.ts
+++ b/src/pages/room/model/useCamStudyRoomStackPageModel.ts
@@ -171,6 +171,9 @@ export function useCamStudyRoomStackPageModel({
     const unsubscribeRoom = chatStompSession.subscribeToRoom({
       roomId,
       participantId,
+      onVideoParticipantOfflined: ({ userId }) => {
+        setParticipants((prev) => prev.filter((p) => p.userId !== userId));
+      },
       onVideoParticipantOnlined: ({
         userId,
         participantId: onlinedParticipantId,

--- a/src/shared/socket/chatStompSession.ts
+++ b/src/shared/socket/chatStompSession.ts
@@ -39,6 +39,7 @@ import type {
   VideoCameraChangedPayload,
   VideoCameraToggleAcceptedPayload,
   VideoParticipantOnlinedPayload,
+  VideoParticipantOfflinedPayload,
   VideoParticipantJoinedPayload,
   VideoParticipantLeftPayload,
   VideoPublishStartedPayload,
@@ -126,6 +127,7 @@ export interface SubscribeToRoomParams {
   onVideoPublishStarted?: (payload: VideoPublishStartedPayload) => void;
   onVideoPublishStopped?: (payload: VideoPublishStoppedPayload) => void;
   onVideoParticipantOnlined?: (payload: VideoParticipantOnlinedPayload) => void;
+  onVideoParticipantOfflined?: (payload: VideoParticipantOfflinedPayload) => void;
   onVideoParticipantJoined?: (payload: VideoParticipantJoinedPayload) => void;
   onVideoParticipantLeft?: (payload: VideoParticipantLeftPayload) => void;
   onVideoRoomDeleted?: (payload: VideoRoomDeletedPayload) => void;
@@ -141,6 +143,7 @@ interface ActiveRoomEntry {
   onVideoPublishStarted?: (payload: VideoPublishStartedPayload) => void;
   onVideoPublishStopped?: (payload: VideoPublishStoppedPayload) => void;
   onVideoParticipantOnlined?: (payload: VideoParticipantOnlinedPayload) => void;
+  onVideoParticipantOfflined?: (payload: VideoParticipantOfflinedPayload) => void;
   onVideoParticipantJoined?: (payload: VideoParticipantJoinedPayload) => void;
   onVideoParticipantLeft?: (payload: VideoParticipantLeftPayload) => void;
   onVideoRoomDeleted?: (payload: VideoRoomDeletedPayload) => void;
@@ -1823,6 +1826,12 @@ class ChatStompSession {
       if (event === "video.participant.online") {
         chatSocketLog("[chat-socket] video.participant.online", { roomId });
         entry.onVideoParticipantOnlined?.(payload as VideoParticipantOnlinedPayload);
+        return;
+      }
+
+      if (event === "video.participant.offline") {
+        chatSocketLog("[chat-socket] video.participant.offline", { roomId });
+        entry.onVideoParticipantOfflined?.(payload as VideoParticipantOfflinedPayload);
         return;
       }
 

--- a/src/shared/socket/model/handshake.types.ts
+++ b/src/shared/socket/model/handshake.types.ts
@@ -214,6 +214,17 @@ export interface VideoParticipantOnlinedPayload {
   at: string;
 }
 
+export interface VideoParticipantOfflinedPayload {
+  eventId: string;
+  roomId: number;
+  participantId: number;
+  userId: number;
+  nickname: string;
+  sessionId: string;
+  cameraEnabled: boolean;
+  at: string;
+}
+
 export interface VideoParticipantJoinedPayload {
   eventId: string;
   roomId: number;


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- 방 퇴장 시 수신되는 `video.participant.offline` 이벤트 타입을 추가했다.
- room 구독 핸들러에서 offline 이벤트를 수신해 콜백으로 전달하도록 연결했다.
- 페이지 모델에서 offline 이벤트 수신 시 참가자를 목록에서 제거해 UI가 즉시 반영되도록 수정했다.

## 작업 배경/목적

- 사용자가 방을 나간 뒤에도 참가자 목록 UI에 남아있는 현상을 해소하기 위함.

## 영향 범위

- CAM_STUDY_ROOM STOMP room 이벤트 타입/분기
- CAM_STUDY_ROOM 참가자 목록 상태 동기화

## 테스트/검증

- `next lint` 훅 통과(기존 저장소 전역 경고만 존재)
- 방 입장/퇴장 시 다른 클라이언트 화면에서 참가자 제거 반영 확인

## 성능 측정 (performance 작업 필수)

- 해당 없음 (performance 라벨/작업 아님)
- 측정 환경: N/A
- 측정 경로(URL): N/A

| 항목 | 변경 전 | 변경 후 | 변화량(Δ) |
|---|---:|---:|---:|
| Performance Score | N/A | N/A | N/A |
| FCP | N/A | N/A | N/A |
| LCP | N/A | N/A | N/A |
| TBT | N/A | N/A | N/A |
| CLS | N/A | N/A | N/A |
| Speed Index | N/A | N/A | N/A |

## 관련 이슈

- Closes #592

## 참고 문서/링크

- 없음
