### PR TITLE
[retro-main #599] feat: 회고 카드 고정 높이/더보기 확장 UI 개선

### DIFF
--- a/src/entities/retro/model/list.ts
+++ b/src/entities/retro/model/list.ts
@@ -24,7 +24,6 @@ export interface MyRetroCardVM extends RetroCoreItem {
 
 export interface PublicRetroCardVM extends RetroCoreItem {
   authorNickname: string;
-  profileImageUrl: string | null;
 }
 
 export type RetroListItem = MyRetroCardVM | PublicRetroCardVM;

--- a/src/entities/retro/model/mappers.ts
+++ b/src/entities/retro/model/mappers.ts
@@ -71,7 +71,6 @@ export function toPublicRetroCardVM(item: PublicRetroItemResponseDto): PublicRet
     defaultLiked: item.isLikedByMe ?? false,
     isMine: item.isMine ?? false,
     authorNickname: item.ownerNickname ?? item.onwerNickname ?? "알 수 없음",
-    profileImageUrl: item.images?.[0]?.url ?? null,
   };
 }
 

--- a/src/entities/retro/ui/RetroCardView.tsx
+++ b/src/entities/retro/ui/RetroCardView.tsx
@@ -32,7 +32,6 @@ export function RetroCardView({
   isOpenChecked,
 }: RetroCardViewProps) {
   const authorNickname = "authorNickname" in vm ? vm.authorNickname : undefined;
-  const profileImageUrl = "profileImageUrl" in vm ? vm.profileImageUrl : undefined;
   const visibilityText = "visibilityText" in vm ? vm.visibilityText : undefined;
   const [selectedImage, setSelectedImage] = useState<{ url: string; alt: string } | null>(null);
 
@@ -42,22 +41,6 @@ export function RetroCardView({
         {authorNickname ? (
           <>
             <div className="flex items-center gap-2">
-              <div className="flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-full bg-neutral-200">
-                {profileImageUrl ? (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img
-                    src={profileImageUrl}
-                    alt={`${authorNickname} 프로필`}
-                    className="h-full w-full object-cover"
-                  />
-                ) : (
-                  <Icon
-                    name="user_outline"
-                    className="h-5 w-5 text-neutral-500"
-                    aria-hidden
-                  />
-                )}
-              </div>
               <span className="text-[16px] font-semibold text-black">{authorNickname}</span>
               <span className="text-[14px] font-medium text-[#9a9a9a]">{vm.dateLabel}</span>
             </div>


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- 공개 회고 카드 VM에 `profileImageUrl` 필드를 추가하고 매퍼를 연결
- 공개 회고 카드 헤더를 프로필 이미지/닉네임/날짜/시간 구조로 재배치
- 본문 영역을 기본 축약 높이로 표시하고, 오버플로우 시 `더보기`/`간단하게 보기` 토글 추가

## 작업 배경/목적

- 회고 카드 레이아웃 개선 이슈(#599) 대응
- 고정 높이 기반 리스트 렌더 안정성을 높이고 긴 본문 가독성을 개선

## 영향 범위

- `src/entities/retro/model/list.ts`
- `src/entities/retro/model/mappers.ts`
- `src/entities/retro/ui/RetroCardView.tsx`
- `src/entities/retro/ui/RetroContentText.tsx`

## 테스트/검증

- 로컬 린트 훅(`next lint`) 통과 후 커밋 완료
- 카드 본문 오버플로우 여부에 따라 `더보기` 버튼 노출/미노출 동작 확인
- `더보기` 토글 시 해당 카드 본문 높이만 확장/축소되는 구조 반영

## 성능 측정 (performance 작업 필수)

- 측정 환경: macOS / Chrome
- 측정 경로(URL): 회고 메인 리스트

| 항목 | 변경 전 | 변경 후 | 변화량(Δ) |
|---|---:|---:|---:|
| Performance Score | 미측정 | 미측정 | - |
| FCP | 미측정 | 미측정 | - |
| LCP | 미측정 | 미측정 | - |
| TBT | 미측정 | 미측정 | - |
| CLS | 미측정 | 미측정 | - |
| Speed Index | 미측정 | 미측정 | - |

## 관련 이슈

- Closes #599

## 참고 문서/링크

- 이슈: https://github.com/100-hours-a-week/7-team-temporary-fe/issues/599
