### PR TITLE
[retro-main #602] feat: 회고 공유하기 버튼 링크 복사 연결

### DIFF
--- a/src/features/retro/ui/RetroListItemCard.tsx
+++ b/src/features/retro/ui/RetroListItemCard.tsx
@@ -136,8 +136,15 @@ export function RetroListItemCard({
     }
   };
 
-  const handleShareClick = () => {
+  const handleShareClick = async () => {
     setIsActionSheetOpen(false);
+    const shareUrl = `${window.location.origin}/retro/public/${vm.id}`;
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      showToast("링크가 복사되었습니다.", "success");
+    } catch {
+      showToast("링크 복사에 실패했습니다.", "error");
+    }
     onShareClick?.();
   };
 
@@ -171,7 +178,7 @@ export function RetroListItemCard({
             >
               <button
                 type="button"
-                onClick={handleShareClick}
+                onClick={() => void handleShareClick()}
                 className="h-12 w-full rounded-xl border border-[#d9d9d9] bg-white text-[16px] font-semibold text-black"
               >
                 공유하기


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- 회고 카드 액션시트의 `공유하기` 버튼 클릭 시 링크 복사 동작을 연결
- 공유 링크를 `/retro/public/{retroId}` 절대 경로로 고정
- 복사 성공/실패 토스트 메시지를 추가하고 액션시트 닫힘 흐름 유지

## 작업 배경/목적

- 회고 공유 UX에서 버튼 클릭 후 실제 액션(링크 복사)이 없던 문제를 해결

## 영향 범위

- `src/features/retro/ui/RetroListItemCard.tsx`

## 테스트/검증

- `pnpm next lint --file src/features/retro/ui/RetroListItemCard.tsx` 통과
- `공유하기` 클릭 시 클립보드 복사 + 성공 토스트 노출 확인
- 클립보드 실패 시 에러 토스트 노출 확인

## 관련 이슈

- Closes #602

## 참고 문서/링크

- 이슈: https://github.com/100-hours-a-week/7-team-temporary-fe/issues/602
