### PR TITLE
[home-domain #605] perf: HOME Suspense fallback 스트리밍 전환

### DIFF
--- a/app/(protected)/home/page.tsx
+++ b/app/(protected)/home/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { QueryClient, dehydrate, HydrationBoundary } from "@tanstack/react-query";
 
 import { AppShellPage } from "@/pages/app-shell";
@@ -28,7 +29,9 @@ function getWeekRange(todayStr: string): { weekStart: string; weekEnd: string } 
   return { weekStart: fmt(start), weekEnd: fmt(end) };
 }
 
-export default async function HomePage() {
+/** 데이터 prefetch 후 HydrationBoundary를 주입하는 async 서버 컴포넌트.
+ *  Suspense로 감싸져 있으므로 await 중에도 서버는 fallback HTML을 먼저 전송한다. */
+async function HomeWithData() {
   const queryClient = new QueryClient();
   const today = getTodayKst();
   const { weekStart, weekEnd } = getWeekRange(today);
@@ -56,5 +59,13 @@ export default async function HomePage() {
     <HydrationBoundary state={dehydrate(queryClient)}>
       <AppShellPage />
     </HydrationBoundary>
+  );
+}
+
+export default function HomePage() {
+  return (
+    <Suspense fallback={<AppShellPage />}>
+      <HomeWithData />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- `app/(protected)/home/page.tsx` 엔트리를 동기 `default export` + `Suspense` 구조로 전환
- `HomeWithData(async)`를 분리해 서버 prefetch(3개 query) 후 `HydrationBoundary`로 스트리밍 응답
- fallback을 `AppShellPage`로 사용해 초기 앱 크롬(헤더/하단 네비) 즉시 노출

## 작업 배경/목적

- HOME 진입 시 FCP 지연을 줄이기 위해 서버 응답의 첫 HTML 전송을 앞당김
- 기존 `async page`에서 prefetch 완료까지 블로킹되던 구간을 `Suspense`로 분리해 TTFB 개선

## 영향 범위

- HOME 라우트 서버 렌더 진입점(`app/(protected)/home/page.tsx`)
- Home 데이터 prefetch/하이드레이션 시점
- AppShell fallback 렌더 타이밍

## 테스트/검증

- pre-commit `next lint` 통과 (기존 경고만 존재, 신규 에러 없음)
- `/home` 진입 시 fallback(AppShell) 우선 노출 후 데이터 하이드레이션 교체 동작 수동 확인

## 성능 측정 (performance 작업 필수)

- 측정 환경: 로컬 개발환경(Chrome DevTools, 추후 CI/실운영 RUM 보강 예정)
- 측정 경로(URL): `/home`

| 항목 | 변경 전 | 변경 후 | 변화량(Δ) |
|---|---:|---:|---:|
| Performance Score | 미측정 | 미측정 | 추후 측정 |
| FCP | 미측정 | 미측정 | 추후 측정 |
| LCP | 미측정 | 미측정 | 추후 측정 |
| TBT | 미측정 | 미측정 | 추후 측정 |
| CLS | 미측정 | 미측정 | 추후 측정 |
| Speed Index | 미측정 | 미측정 | 추후 측정 |

## 관련 이슈

- Closes #605

## 참고 문서/링크

- 이슈: https://github.com/100-hours-a-week/7-team-temporary-fe/issues/605
- 트러블슈팅 문서(위키 로컬 작업본): `7-team-temporary-fe.wiki/app-shell-home-fcp-suspense-streaming-troubleshooting.md`
