### PR TITLE
[home-domain #607] fix: 제외리스트 시트 확장 상태 불일치 수정

### DIFF
--- a/src/widgets/planner-edit/model/useExcludedTasksSheetState.ts
+++ b/src/widgets/planner-edit/model/useExcludedTasksSheetState.ts
@@ -8,7 +8,7 @@ export function useExcludedTasksSheetState(defaultOpen = true) {
 
   const openExcludedTasksSheet = useCallback(() => {
     setIsExcludedSheetOpen(true);
-    setIsExcludedSheetExpanded(false);
+    setIsExcludedSheetExpanded(true);
   }, []);
 
   return {


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- 제외리스트 오픈 액션에서 시트 확장 상태를 `false -> true`로 수정
- 제외리스트 버튼 클릭 시 바텀시트가 확장 상태로 열리도록 동작 정렬

## 작업 배경/목적

- `#607` 버그 이슈: 제외리스트 DnD 복귀 동선에서 시트가 축소 상태로 열려 사용자 조작이 막히는 문제 대응

## 영향 범위

- `src/widgets/planner-edit/model/useExcludedTasksSheetState.ts`
- PlannerEdit 제외리스트 오픈/확장 상태 관리

## 테스트/검증

- 제외리스트 버튼 클릭 시 시트가 확장된 상태로 열리는지 확인
- 기존 제외리스트 열기/닫기 동작 회귀 없음 확인

## 관련 이슈

- Closes #607

## 참고 문서/링크

- 이슈: https://github.com/100-hours-a-week/7-team-temporary-fe/issues/607
