### PR TITLE
[chat-perf #571] fix: ChatMessageFeed 메시지 key 안정화

### DIFF
--- a/src/widgets/chat-room-message-feed/ui/ChatMessageFeed.tsx
+++ b/src/widgets/chat-room-message-feed/ui/ChatMessageFeed.tsx
@@ -110,7 +110,7 @@ export function ChatMessageFeed({
       if (currentDateKey && currentDateKey !== previousDateKey) {
         nextItems.push({
           kind: "DATE_DIVIDER",
-          key: `date-divider-${currentDateKey}-${messageIndex}`,
+          key: `date-divider-${currentDateKey}-first-${message.messageId}`,
           label: formatDateDividerLabel(message.sentAt),
         });
         previousDateKey = currentDateKey;
@@ -118,7 +118,7 @@ export function ChatMessageFeed({
 
       nextItems.push({
         kind: "MESSAGE",
-        key: `message-${message.messageId}-${message.sentAt}-${messageIndex}`,
+        key: `message-${message.messageId}`,
         message,
         messageIndex,
       });


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- `ChatMessageFeed` 메시지 key에서 `messageIndex`/`sentAt` 의존을 제거하고 `messageId` 기반 안정 키로 전환
- 날짜 구분선(DATE_DIVIDER) key에서 `messageIndex` 의존을 제거하고 날짜 + 첫 메시지 id 기반 키로 전환

## 작업 배경/목적

- 과거 메시지 prepend(상단 페이지네이션) 시 index 기반 key가 밀리면서 대량 remount가 발생할 수 있어,
  스크롤 점프/깜빡임 리스크를 줄이기 위한 key 안정화가 필요함

## 영향 범위

- `src/widgets/chat-room-message-feed/ui/ChatMessageFeed.tsx`
- 채팅 메시지 피드 리스트 identity 안정성 및 prepend 렌더링 비용

## 테스트/검증

- 코드 레벨 검증: 메시지 key / divider key에서 `messageIndex` 의존 제거 확인
- 수동 검증 권장: 채팅방 상단 과거 메시지 반복 로드 시 스크롤 점프/깜빡임 체감 확인

## 성능 측정 (performance 작업 필수)

- 측정 환경: 로컬 개발환경 (Chrome DevTools)
- 측정 경로(URL): `/chat/[roomId]`

| 항목 | 변경 전 | 변경 후 | 변화량(Δ) |
|---|---:|---:|---:|
| Performance Score | 미측정 | 미측정 | 추후 측정 |
| FCP | 미측정 | 미측정 | 추후 측정 |
| LCP | 미측정 | 미측정 | 추후 측정 |
| TBT | 미측정 | 미측정 | 추후 측정 |
| CLS | 미측정 | 미측정 | 추후 측정 |
| Speed Index | 미측정 | 미측정 | 추후 측정 |

## 관련 이슈

- Closes #571

## 참고 문서/링크

- 이슈: https://github.com/100-hours-a-week/7-team-temporary-fe/issues/571
