### PR TITLE
release(2.0.2): 최신 develop 변경 반영

### DIFF
--- a/src/entities/chat-room/model/useChatRoomRealtime.ts
+++ b/src/entities/chat-room/model/useChatRoomRealtime.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 
 import { chatStompSession } from "@/shared/socket";
 
@@ -12,6 +12,7 @@ interface UseChatRoomRealtimeOptions {
   participantId?: number;
   myUserId?: number | null;
   enabled?: boolean;
+  onMessage?: (vm: ChatMessageItemVM) => void;
 }
 
 export function useChatRoomRealtime({
@@ -19,10 +20,13 @@ export function useChatRoomRealtime({
   participantId,
   myUserId = null,
   enabled = true,
+  onMessage,
 }: UseChatRoomRealtimeOptions) {
-  const [realtimeMessages, setRealtimeMessages] = useState<ChatMessageItemVM[]>([]);
   const myUserIdRef = useRef(myUserId);
   myUserIdRef.current = myUserId;
+
+  const onMessageRef = useRef(onMessage);
+  onMessageRef.current = onMessage;
 
   useEffect(() => {
     if (!enabled || roomId <= 0) return;
@@ -32,10 +36,8 @@ export function useChatRoomRealtime({
       participantId,
       onMessageCreated: (payload) => {
         const vm = messageCreatedPayloadToVM(payload, myUserIdRef.current);
-        setRealtimeMessages((prev) => [...prev, vm]);
+        onMessageRef.current?.(vm);
       },
     });
   }, [enabled, roomId, participantId]);
-
-  return { realtimeMessages };
 }

--- a/src/features/chat-room-session/model/useChatRoomSessionModel.ts
+++ b/src/features/chat-room-session/model/useChatRoomSessionModel.ts
@@ -2,9 +2,9 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { useQueryClient } from "@tanstack/react-query";
+import { type InfiniteData, useQueryClient } from "@tanstack/react-query";
 
-import type { ChatMessageItemVM } from "@/entities/chat-room";
+import type { ChatMessageItemVM, ChatMessageListModel } from "@/entities/chat-room";
 import {
   chatRoomQueryKeys,
   useChatRoomDetailQuery,
@@ -118,13 +118,6 @@ export function useChatRoomSessionModel({
     enabled: isRoomEnabled,
   });
 
-  const { realtimeMessages } = useChatRoomRealtime({
-    roomId,
-    participantId: myParticipantId,
-    myUserId,
-    enabled: isChatRuntimeEnabled && myParticipantId !== undefined,
-  });
-
   useEffect(() => {
     lastRoomFeedPatchedMessageIdRef.current = 0;
   }, [roomId]);
@@ -181,6 +174,43 @@ export function useChatRoomSessionModel({
     [queryClient, roomId],
   );
 
+  const onRealtimeMessage = useCallback(
+    (vm: ChatMessageItemVM) => {
+      queryClient.setQueryData<InfiniteData<ChatMessageListModel>>(
+        chatRoomQueryKeys.messagesInfinite(roomId, CHAT_ROOM_MESSAGE_PAGE_SIZE, myUserId),
+        (old) => {
+          if (!old) return old;
+          const lastPage = old.pages[old.pages.length - 1];
+          return {
+            ...old,
+            pages: [...old.pages.slice(0, -1), { ...lastPage, content: [...lastPage.content, vm] }],
+          };
+        },
+      );
+
+      if (
+        vm.senderType === "USER" &&
+        vm.senderId === myUserId &&
+        vm.messageId > lastRoomFeedPatchedMessageIdRef.current
+      ) {
+        lastRoomFeedPatchedMessageIdRef.current = vm.messageId;
+        patchRoomFeedLatestMessage({
+          lastMessage: toRoomFeedPreviewFromMessage(vm),
+          lastMessageAt: vm.sentAt,
+        });
+      }
+    },
+    [myUserId, patchRoomFeedLatestMessage, queryClient, roomId],
+  );
+
+  useChatRoomRealtime({
+    roomId,
+    participantId: myParticipantId,
+    myUserId,
+    enabled: isChatRuntimeEnabled && myParticipantId !== undefined,
+    onMessage: onRealtimeMessage,
+  });
+
   useEffect(() => {
     return chatStompSession.onMessageSendAccepted(({ idempotencyKey }) => {
       setPendingMessages((prev) => {
@@ -191,23 +221,6 @@ export function useChatRoomSessionModel({
       });
     });
   }, []);
-
-  useEffect(() => {
-    if (myUserId === null) return;
-    if (realtimeMessages.length === 0) return;
-
-    const latestMine = [...realtimeMessages]
-      .reverse()
-      .find((message) => message.senderType === "USER" && message.senderId === myUserId);
-    if (!latestMine) return;
-    if (latestMine.messageId <= lastRoomFeedPatchedMessageIdRef.current) return;
-
-    lastRoomFeedPatchedMessageIdRef.current = latestMine.messageId;
-    patchRoomFeedLatestMessage({
-      lastMessage: toRoomFeedPreviewFromMessage(latestMine),
-      lastMessageAt: latestMine.sentAt,
-    });
-  }, [myUserId, patchRoomFeedLatestMessage, realtimeMessages]);
 
   useEffect(() => {
     return chatStompSession.onMessageSendFailed(({ idempotencyKey, message }) => {
@@ -233,23 +246,9 @@ export function useChatRoomSessionModel({
     });
   }, [queryClient, showToast]);
 
-  const historicalMessageIds = useMemo(
-    () => new Set(chatMessagesQuery.messages.map((message) => message.messageId)),
-    [chatMessagesQuery.messages],
-  );
-
-  const newRealtimeMessages = useMemo(
-    () => realtimeMessages.filter((message) => !historicalMessageIds.has(message.messageId)),
-    [realtimeMessages, historicalMessageIds],
-  );
-
   const messages = useMemo(
-    () => [
-      ...chatMessagesQuery.messages,
-      ...newRealtimeMessages,
-      ...Array.from(pendingMessages.values()),
-    ],
-    [chatMessagesQuery.messages, newRealtimeMessages, pendingMessages],
+    () => [...chatMessagesQuery.messages, ...Array.from(pendingMessages.values())],
+    [chatMessagesQuery.messages, pendingMessages],
   );
 
   const latestConfirmedMessageId = useMemo(


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- `develop`의 최신 변경을 `release/2.0.2`로 반영
- 포함 핵심 변경: 채팅 실시간 메시지 누적 참조 제거 및 캐시 직접 반영 (#613)

## 포함 커밋

- `98f3948` Merge pull request #614 from 100-hours-a-week/perf/chat-perf-613
- `255a0c3` fix(chat-perf): 실시간 메시지 상태 누적 제거 및 캐시 직접 반영 (#613)

## 영향 범위

- 채팅방 실시간 메시지 수신/반영 경로
- 채팅방 세션 메시지 리스트 구성

## 테스트/검증

- release 브랜치 반영 후 QA에서 채팅방 입장/이탈 반복, room 전환, 실시간 메시지 수신 동선 확인 필요

## 관련 이슈

- Refs #613
