### PR TITLE
[chat-perf #618] feat: room·retro 페이지 suspense 경계 적용

### DIFF
--- a/app/(protected)/retro/page.tsx
+++ b/app/(protected)/retro/page.tsx
@@ -1,10 +1,11 @@
+import { Suspense } from "react";
 import { QueryClient, dehydrate, HydrationBoundary } from "@tanstack/react-query";
 
 import { AppShellPage } from "@/pages/app-shell";
 import { serverFetch, serverTaskPath } from "@/shared/api/serverFetch";
 import { retroQueryKeys } from "@/entities/retro";
 
-export default async function RetroPage() {
+async function RetroWithData() {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -28,5 +29,13 @@ export default async function RetroPage() {
     <HydrationBoundary state={dehydrate(queryClient)}>
       <AppShellPage />
     </HydrationBoundary>
+  );
+}
+
+export default function RetroPage() {
+  return (
+    <Suspense fallback={<AppShellPage />}>
+      <RetroWithData />
+    </Suspense>
   );
 }

--- a/app/(protected)/room/page.tsx
+++ b/app/(protected)/room/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { QueryClient, dehydrate, HydrationBoundary } from "@tanstack/react-query";
 
 import { AppShellPage } from "@/pages/app-shell";
@@ -5,7 +6,7 @@ import { serverFetch, serverChatPath } from "@/shared/api/serverFetch";
 import { chatRoomQueryKeys } from "@/entities/chat-room";
 import { camStudyRoomQueryKeys } from "@/entities/cam-study-room";
 
-export default async function RoomPage() {
+async function RoomWithData() {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -31,5 +32,13 @@ export default async function RoomPage() {
     <HydrationBoundary state={dehydrate(queryClient)}>
       <AppShellPage />
     </HydrationBoundary>
+  );
+}
+
+export default function RoomPage() {
+  return (
+    <Suspense fallback={<AppShellPage />}>
+      <RoomWithData />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- ROOM/RETRO 보호 페이지를 `Suspense` 경계 + `WithData` async 서버 컴포넌트 구조로 분리
- fallback으로 `AppShellPage`를 즉시 렌더하고, prefetch 완료 후 `HydrationBoundary`로 데이터 주입
- 초기 진입에서 빈 화면 체감 시간을 줄이고 prefetch 흐름을 페이지 단위로 명확화

## 작업 배경/목적

- 이슈 #618의 목표인 ROOM 페이지 Suspense 기반 prefetch 스트리밍 적용과 동일 패턴을 RETRO 페이지에도 일관 적용

## 영향 범위

- `app/(protected)/room/page.tsx`
- `app/(protected)/retro/page.tsx`

## 테스트/검증

- 커밋 훅 기준 `next lint` 통과
- 보호 페이지 진입 시 fallback 즉시 렌더 및 데이터 하이드레이션 전환 동작 수동 확인

## 성능 측정 (performance 작업 필수)

- 측정 환경: Chrome DevTools / Lighthouse
- 측정 경로(URL): `/room`, `/retro` 첫 진입

| 항목 | 변경 전 | 변경 후 | 변화량(Δ) |
|---|---:|---:|---:|
| Performance Score | 측정 예정 | 측정 예정 | 측정 예정 |
| FCP | 측정 예정 | 측정 예정 | 측정 예정 |
| LCP | 측정 예정 | 측정 예정 | 측정 예정 |
| TBT | 측정 예정 | 측정 예정 | 측정 예정 |
| CLS | 측정 예정 | 측정 예정 | 측정 예정 |
| Speed Index | 측정 예정 | 측정 예정 | 측정 예정 |

## 관련 이슈

- Closes #618

## 참고 문서/링크

- Issue: https://github.com/100-hours-a-week/7-team-temporary-fe/issues/618
