### PR TITLE
[chat-perf #632] fix: ROOM Suspense fallback 경합 제거

### DIFF
--- a/app/(protected)/room/page.tsx
+++ b/app/(protected)/room/page.tsx
@@ -1,11 +1,12 @@
-import { Suspense } from "react";
 import { QueryClient, dehydrate, HydrationBoundary } from "@tanstack/react-query";
 
 import { AppShellPage } from "@/pages/app-shell";
 import { serverFetch, serverChatPath } from "@/shared/api/serverFetch";
 import { chatRoomQueryKeys } from "@/entities/chat-room-query-keys";
 
-async function RoomWithData() {
+// Suspense 스트리밍 제거 — fallback이 HydrationBoundary 없이 마운트되면
+// dynamic import 완료 시점에 캐시가 비어 있어 클라이언트 재요청이 발생하는 race condition 방지
+export default async function RoomPage() {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -25,13 +26,5 @@ async function RoomWithData() {
     <HydrationBoundary state={dehydrate(queryClient)}>
       <AppShellPage />
     </HydrationBoundary>
-  );
-}
-
-export default function RoomPage() {
-  return (
-    <Suspense fallback={<AppShellPage />}>
-      <RoomWithData />
-    </Suspense>
   );
 }


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- `/room` 페이지의 `Suspense fallback={<AppShellPage />}` 래핑을 제거했습니다.
- `RoomPage`를 async 서버 컴포넌트로 전환해 prefetch + `HydrationBoundary` 단일 경로로 동작하게 정리했습니다.
- fallback 경로에서 발생하던 캐시 주입 경합(race) 가능성을 줄여 초기 중복 요청 리스크를 낮췄습니다.

## 작업 배경/목적

- fallback UI가 `HydrationBoundary` 없이 먼저 마운트되면 클라이언트 fetch가 선행될 수 있어, 서버 prefetch 캐시 주입 시점과 경합이 발생할 수 있었습니다.
- 초기 렌더 경로를 단일화해 네트워크/렌더 흐름의 예측 가능성을 높이는 것이 목적입니다.

## 영향 범위

- `app/(protected)/room/page.tsx`

## 테스트/검증

- pre-commit `next lint` 실행 통과(기존 경고만 존재)
- 코드 경로 검증: Suspense fallback 제거 및 async 서버 컴포넌트 경로 확인

## 성능 측정 (performance 작업 필수)

- 측정 환경: 로컬 개발 환경
- 측정 경로(URL): `/room`

| 항목 | 변경 전 | 변경 후 | 변화량(Δ) |
|---|---:|---:|---:|
| Performance Score | 측정 예정 | 측정 예정 | 측정 예정 |
| FCP | 측정 예정 | 측정 예정 | 측정 예정 |
| LCP | 측정 예정 | 측정 예정 | 측정 예정 |
| TBT | 측정 예정 | 측정 예정 | 측정 예정 |
| CLS | 측정 예정 | 측정 예정 | 측정 예정 |
| Speed Index | 측정 예정 | 측정 예정 | 측정 예정 |

## 관련 이슈

- Closes #632

## 참고 문서/링크

- 이슈: https://github.com/100-hours-a-week/7-team-temporary-fe/issues/632
