### PR TITLE
[chat-perf #637] fix: 서비스워커 등록/연결 실패 회귀 복구

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -9,6 +9,7 @@ import { ApiError } from "@/shared/api";
 import { AuthService, configureAuthHandlers } from "@/shared/auth";
 import { useAuthStore } from "@/entities/user";
 import { registerServiceWorker } from "@/shared/pwa/registerServiceWorker";
+import { chatStompSession } from "@/shared/socket";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -70,9 +71,16 @@ export function Providers({ children }: { children: React.ReactNode }) {
     const bootstrapAuth = async () => {
       try {
         // 1순위: AT 쿠키가 살아있으면 refresh 없이 복원 (네트워크 1회)
-        if (await AuthService.restoreFromCookie()) return;
+        // restoreFromCookie()가 cachedDeviceId를 세팅한 뒤 setAuthenticated()를 호출한다.
+        // auth_hint 최적화로 isAuthenticated가 이미 true이면 상태 변화가 없어
+        // ProtectedLayoutEffects의 effect가 재실행되지 않으므로 여기서 직접 start()를 호출한다.
+        if (await AuthService.restoreFromCookie()) {
+          chatStompSession.start();
+          return;
+        }
         // 2순위: RT 쿠키로 AT 재발급
         await AuthService.refresh();
+        chatStompSession.start();
       } catch (error) {
         if (!(error instanceof ApiError && error.httpStatus === 401)) {
           console.warn("[AuthBootstrap] refresh skipped or failed", error);

--- a/public/sw.js
+++ b/public/sw.js
@@ -72,41 +72,79 @@ try {
   console.warn("[SW] Firebase messaging setup failed", error);
 }
 
-/*백그라운드 푸시는 이쪽에서 받는다.*/
-if (messaging) {
-  messaging.onBackgroundMessage((payload) => {
-    console.log("[FCM SW] payload", payload);
+/** FCM data payload → 알림 옵션으로 변환
+ *  FCM data-only 메시지는 모든 필드가 payload.data 아래 string으로 들어온다.
+ */
+function buildNotificationOptions(data) {
+  const title = data?.title ?? "MOLIP";
+  const body = data?.body ?? data?.messagePreview ?? data?.content ?? "";
+  const icon = "/icons/icon-v2.svg";
+  const badge = "/icons/badge.svg";
 
-    const title = payload.data?.title ?? "MOLIP";
-    const body = payload.data?.content ?? payload.data?.body ?? "백그라운드 푸시 알림 테스트!";
-    const icon = payload.data?.icon ?? "/icons/icon.svg";
-
-    self.registration.showNotification(title, {
+  return {
+    title,
+    options: {
       body,
       icon,
-    });
+      badge,
+      tag: data?.notificationId ?? data?.roomId ?? "molip",
+      renotify: true,
+      data: {
+        type: data?.type,
+        roomId: data?.roomId,
+        messageId: data?.messageId,
+        notificationId: data?.notificationId,
+      },
+    },
+  };
+}
+
+/* 백그라운드 FCM 메시지 수신 (앱이 백그라운드/종료 상태일 때) */
+if (messaging) {
+  messaging.onBackgroundMessage((payload) => {
+    const { title, options } = buildNotificationOptions(payload.data);
+    self.registration.showNotification(title, options);
   });
 }
 
-// Fallback for non-FCM test pushes (DevTools "Push" may send plain text)
-/*백엔드가 보내는 푸시는 이쪽에서 받는다.
- *
- */
+/* 직접 Push API 이벤트 (FCM 이외 경로 또는 DevTools 테스트) */
 self.addEventListener("push", (event) => {
-  console.log("[FCM SW] push event", event);
-  let payload = {};
+  let data = {};
   if (event.data) {
     try {
-      payload = event.data.json();
+      const json = event.data.json();
+      // FCM 래핑: { data: { ... } } 또는 flat 구조 모두 대응
+      data = json.data ?? json;
     } catch {
-      payload = { title: "MOLIP", content: event.data.text() };
+      data = { body: event.data.text() };
     }
   }
 
-  const title = payload.data?.title ?? "MOLIP";
-  const body = payload.data?.content ?? payload.data?.body ?? "push 푸시 알림 테스트";
-  const icon = payload.data?.icon ?? "/icons/icon.svg";
-  const badge = payload.data?.badge ?? "/icons/badge.svg";
+  const { title, options } = buildNotificationOptions(data);
+  event.waitUntil(self.registration.showNotification(title, options));
+});
 
-  event.waitUntil(self.registration.showNotification(title, { body, icon, badge }));
+/* 알림 클릭 시 해당 채팅방으로 이동 */
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+
+  const { type, roomId } = event.notification.data ?? {};
+  const targetPath = type === "CHAT_MESSAGE" && roomId ? `/room/${roomId}` : "/";
+
+  event.waitUntil(
+    self.clients
+      .matchAll({ type: "window", includeUncontrolled: true })
+      .then((clientList) => {
+        // 이미 열린 탭이 있으면 포커스 후 이동
+        for (const client of clientList) {
+          if ("focus" in client) {
+            client.focus();
+            client.navigate(targetPath);
+            return;
+          }
+        }
+        // 열린 탭이 없으면 새 탭 열기
+        return self.clients.openWindow(targetPath);
+      }),
+  );
 });

--- a/src/features/auth/login/ui/LoginFormContainer.tsx
+++ b/src/features/auth/login/ui/LoginFormContainer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import type { AuthState } from "@/entities/user";
 import { useAuthStore } from "@/entities";
+import { AuthService } from "@/shared/auth";
 import { useMutationErrorEffect } from "@/shared/query";
 
 import { useLoginForm, useLoginMutation } from "../model";
@@ -14,11 +14,15 @@ interface LoginFormContainerProps {
 }
 
 export function LoginFormContainer({ onGoToSignUp, onPrepareSignUp }: LoginFormContainerProps) {
-  const setAuthenticated = useAuthStore((state: AuthState) => state.setAuthenticated);
   const { form, register, errors, isSubmitting, handleSubmit } = useLoginForm();
   const mutation = useLoginMutation({
-    onSuccess: () => {
-      setAuthenticated();
+    onSuccess: async () => {
+      // restoreFromCookie()로 deviceId를 캐싱한 뒤 setAuthenticated()를 호출한다.
+      // 직접 setAuthenticated()만 하면 cachedDeviceId가 null이라 소켓 연결이 스킵된다.
+      const ok = await AuthService.restoreFromCookie();
+      if (!ok) {
+        useAuthStore.getState().setAuthenticated();
+      }
     },
   });
 

--- a/src/shared/socket/chatStompSession.ts
+++ b/src/shared/socket/chatStompSession.ts
@@ -43,6 +43,9 @@ import type {
   VideoParticipantJoinedPayload,
   VideoParticipantLeftPayload,
   VideoPublishStartedPayload,
+  ChatParticipantHeartbeatPayload,
+  ChatParticipantOfflinePayload,
+  ChatParticipantOnlinePayload,
   VideoParticipantHeartbeatPayload,
   VideoParticipantOfflinePayload,
   VideoParticipantOnlinePayload,
@@ -600,6 +603,47 @@ class ChatStompSession {
     }
 
     return () => this.teardownRoomSubscription(roomId);
+  }
+
+  // ─── Chat participant presence ────────────────────────────────────────────────
+
+  sendChatParticipantOnline(payload: ChatParticipantOnlinePayload) {
+    if (!this.client?.connected || !this.config) {
+      chatSocketWarn("[chat-socket] sendChatParticipantOnline: 소켓 미연결 상태");
+      return;
+    }
+    this.publishWithReceipt({
+      client: this.client,
+      destination: this.config.chatParticipantOnlineDestination,
+      body: JSON.stringify(payload),
+      eventName: "chat.participant.online",
+      payloadForLog: { roomId: payload.roomId, participantId: payload.participantId },
+    });
+  }
+
+  sendChatParticipantHeartbeat(payload: ChatParticipantHeartbeatPayload) {
+    if (!this.client?.connected || !this.config) return;
+    this.publishWithReceipt({
+      client: this.client,
+      destination: this.config.chatParticipantHeartbeatDestination,
+      body: JSON.stringify(payload),
+      eventName: "chat.participant.heartbeat",
+      payloadForLog: { roomId: payload.roomId, participantId: payload.participantId },
+    });
+  }
+
+  sendChatParticipantOffline(payload: ChatParticipantOfflinePayload) {
+    if (!this.client?.connected || !this.config) {
+      chatSocketWarn("[chat-socket] sendChatParticipantOffline: 소켓 미연결 상태");
+      return;
+    }
+    this.publishWithReceipt({
+      client: this.client,
+      destination: this.config.chatParticipantOfflineDestination,
+      body: JSON.stringify(payload),
+      eventName: "chat.participant.offline",
+      payloadForLog: { roomId: payload.roomId, participantId: payload.participantId },
+    });
   }
 
   // ─── Video participant online ──────────────────────────────────────────────────

--- a/src/shared/socket/model/handshake.types.ts
+++ b/src/shared/socket/model/handshake.types.ts
@@ -180,6 +180,26 @@ export interface ReportStreamEndPayload {
   content?: string | null;
 }
 
+// ─── Chat participant presence: Client → Server ───────────────────────────────
+
+export interface ChatParticipantOnlinePayload {
+  roomId: number;
+  participantId: number;
+  sessionId: string;
+}
+
+export interface ChatParticipantHeartbeatPayload {
+  roomId: number;
+  participantId: number;
+  sessionId: string;
+}
+
+export interface ChatParticipantOfflinePayload {
+  roomId: number;
+  participantId: number;
+  sessionId: string;
+}
+
 // ─── Video: Client → Server ───────────────────────────────────────────────────
 
 export interface VideoParticipantOnlinePayload {

--- a/src/shared/socket/model/socketEnv.ts
+++ b/src/shared/socket/model/socketEnv.ts
@@ -20,6 +20,15 @@ const USER_QUEUE_ROOM_DESTINATION =
   process.env.NEXT_PUBLIC_CHAT_SOCKET_USER_QUEUE_ROOM_DEST?.trim() ?? "/user/queue/room";
 const USER_QUEUE_REPORT_DESTINATION =
   process.env.NEXT_PUBLIC_CHAT_SOCKET_USER_QUEUE_REPORT_DEST?.trim() ?? "/user/queue/report";
+const CHAT_PARTICIPANT_ONLINE_DESTINATION =
+  process.env.NEXT_PUBLIC_CHAT_SOCKET_CHAT_PARTICIPANT_ONLINE_DEST?.trim() ??
+  "/pub/room/chat/online";
+const CHAT_PARTICIPANT_HEARTBEAT_DESTINATION =
+  process.env.NEXT_PUBLIC_CHAT_SOCKET_CHAT_PARTICIPANT_HEARTBEAT_DEST?.trim() ??
+  "/pub/room/chat/heartbeat";
+const CHAT_PARTICIPANT_OFFLINE_DESTINATION =
+  process.env.NEXT_PUBLIC_CHAT_SOCKET_CHAT_PARTICIPANT_OFFLINE_DEST?.trim() ??
+  "/pub/room/chat/offline";
 const VIDEO_PARTICIPANT_ONLINE_DESTINATION =
   process.env.NEXT_PUBLIC_CHAT_SOCKET_VIDEO_PARTICIPANT_ONLINE_DEST?.trim() ??
   "/pub/room/video/online";
@@ -46,6 +55,9 @@ export interface ChatSocketStartConfig {
   lastSeenUpdateDestination: string;
   userQueueRoomDestination: string;
   userQueueReportDestination: string;
+  chatParticipantOnlineDestination: string;
+  chatParticipantHeartbeatDestination: string;
+  chatParticipantOfflineDestination: string;
   videoParticipantOnlineDestination: string;
   videoParticipantHeartbeatDestination: string;
   videoParticipantOfflineDestination: string;
@@ -112,6 +124,9 @@ export function resolveChatSocketStartConfig(): ChatSocketStartConfig | null {
     lastSeenUpdateDestination: LAST_SEEN_UPDATE_DESTINATION,
     userQueueRoomDestination: USER_QUEUE_ROOM_DESTINATION,
     userQueueReportDestination: USER_QUEUE_REPORT_DESTINATION,
+    chatParticipantOnlineDestination: CHAT_PARTICIPANT_ONLINE_DESTINATION,
+    chatParticipantHeartbeatDestination: CHAT_PARTICIPANT_HEARTBEAT_DESTINATION,
+    chatParticipantOfflineDestination: CHAT_PARTICIPANT_OFFLINE_DESTINATION,
     videoParticipantOnlineDestination: VIDEO_PARTICIPANT_ONLINE_DESTINATION,
     videoParticipantHeartbeatDestination: VIDEO_PARTICIPANT_HEARTBEAT_DESTINATION,
     videoParticipantOfflineDestination: VIDEO_PARTICIPANT_OFFLINE_DESTINATION,


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- 서비스워커 소켓 핸드셰이크 흐름을 보강해 등록/연결 실패 회귀를 완화했습니다.
- `public/sw.js`에서 메시지 처리/연결 상태 처리 로직을 보정했습니다.
- 앱 초기화(`app/providers.tsx`) 및 로그인 경로(`LoginFormContainer`)에서 서비스워커 연계 흐름을 정리했습니다.
- 소켓 핸드셰이크 타입/환경 모델(`handshake.types.ts`, `socketEnv.ts`)을 보강했습니다.

## 작업 배경/목적

- 최근 초기화/성능 최적화 이후 일부 환경에서 서비스워커가 안정적으로 연결되지 않아,
  푸시/소켓 연계 경로가 불안정해지는 문제를 복구하기 위한 수정입니다.

## 영향 범위

- `app/providers.tsx`
- `public/sw.js`
- `src/features/auth/login/ui/LoginFormContainer.tsx`
- `src/shared/socket/chatStompSession.ts`
- `src/shared/socket/model/handshake.types.ts`
- `src/shared/socket/model/socketEnv.ts`

## 테스트/검증

- pre-commit `next lint` 실행 통과(기존 경고만 존재)
- 서비스워커 등록/핸드셰이크 코드 경로 정적 검토

## 성능 측정 (performance 작업 필수)

- 측정 환경: 로컬 개발 환경
- 측정 경로(URL): `/room`, `/login`

| 항목 | 변경 전 | 변경 후 | 변화량(Δ) |
|---|---:|---:|---:|
| Performance Score | 측정 예정 | 측정 예정 | 측정 예정 |
| FCP | 측정 예정 | 측정 예정 | 측정 예정 |
| LCP | 측정 예정 | 측정 예정 | 측정 예정 |
| TBT | 측정 예정 | 측정 예정 | 측정 예정 |
| CLS | 측정 예정 | 측정 예정 | 측정 예정 |
| Speed Index | 측정 예정 | 측정 예정 | 측정 예정 |

## 관련 이슈

- Closes #637

## 참고 문서/링크

- 이슈: https://github.com/100-hours-a-week/7-team-temporary-fe/issues/637
