### PR TITLE
[chat-api #640] fix: 채팅방 입장 시 presence online/offline 발행 복구

### DIFF
--- a/src/shared/socket/chatStompSession.ts
+++ b/src/shared/socket/chatStompSession.ts
@@ -74,6 +74,7 @@ const DEFAULT_LOGOUT_DISCONNECT_PAYLOAD: DisconnectHandshakePayload = {
 };
 
 const PUBLISH_RECEIPT_TIMEOUT_MS = 3000;
+const CHAT_PARTICIPANT_HEARTBEAT_INTERVAL_MS = 15_000;
 const DUPLICATE_RECONNECT_BASE_DELAY_MS = 1000;
 const DUPLICATE_RECONNECT_MAX_DELAY_MS = 8000;
 const DUPLICATE_RECONNECT_MAX_RETRIES = 8;
@@ -139,6 +140,7 @@ export interface SubscribeToRoomParams {
 interface ActiveRoomEntry {
   participantId: number;
   stompSubscription: StompSubscription | null;
+  chatHeartbeatTimer: ReturnType<typeof setInterval> | null;
   onMessageCreated?: (payload: MessageCreatedPayload) => void;
   onParticipantJoined?: (payload: ParticipantJoinedPayload) => void;
   onParticipantLeft?: (payload: ParticipantLeftPayload) => void;
@@ -423,6 +425,7 @@ class ChatStompSession {
   private config: ChatSocketStartConfig | null = null;
   private isRefreshing = false;
   private connectedUserId: number | null = null;
+  private connectedSessionId: string | null = null;
 
   // Active STOMP subscriptions (cleared on each reconnect)
   private handshakeSubscription: StompSubscription | null = null;
@@ -462,6 +465,10 @@ class ChatStompSession {
 
   get userId(): number | null {
     return this.connectedUserId;
+  }
+
+  get sessionId(): string | null {
+    return this.connectedSessionId;
   }
 
   // ─── Public listener registration ────────────────────────────────────────────
@@ -594,6 +601,7 @@ class ChatStompSession {
     const entry: ActiveRoomEntry = {
       participantId,
       stompSubscription: null,
+      chatHeartbeatTimer: null,
       ...callbacks,
     };
     this.activeRooms.set(roomId, entry);
@@ -981,6 +989,7 @@ class ChatStompSession {
     this.client = null;
     this.config = null;
     this.connectedUserId = null;
+    this.connectedSessionId = null;
   }
 
   private clearScheduledRefreshReconnectTimer() {
@@ -1416,6 +1425,7 @@ class ChatStompSession {
       if (connectedPayload) {
         chatSocketLog("[chat-socket] socket.connected", connectedPayload);
         this.connectedUserId = connectedPayload.userId;
+        this.connectedSessionId = connectedPayload.sessionId;
         setAuthUserId(connectedPayload.userId);
         this.resetReconnectState();
 
@@ -1789,6 +1799,12 @@ class ChatStompSession {
     roomId: number,
     entry: ActiveRoomEntry,
   ) {
+    // 재연결 시 기존 heartbeat 타이머가 살아있을 수 있으므로 먼저 정리한다.
+    if (entry.chatHeartbeatTimer !== null) {
+      clearInterval(entry.chatHeartbeatTimer);
+      entry.chatHeartbeatTimer = null;
+    }
+
     const destination = `/sub/room/${roomId}`;
 
     entry.stompSubscription = client.subscribe(destination, (message) => {
@@ -1916,6 +1932,29 @@ class ChatStompSession {
       payloadForLog: subscribePayload,
     });
 
+    const sessionId = this.connectedSessionId;
+    if (sessionId) {
+      this.sendChatParticipantOnline({
+        roomId,
+        participantId: entry.participantId,
+        sessionId,
+      });
+      entry.chatHeartbeatTimer = setInterval(() => {
+        const currentSessionId = this.connectedSessionId;
+        if (!currentSessionId) return;
+        this.sendChatParticipantHeartbeat({
+          roomId,
+          participantId: entry.participantId,
+          sessionId: currentSessionId,
+        });
+      }, CHAT_PARTICIPANT_HEARTBEAT_INTERVAL_MS);
+    } else {
+      chatSocketWarn("[chat-socket] skip chat.participant.online: sessionId 미확보", {
+        roomId,
+        participantId: entry.participantId,
+      });
+    }
+
     chatSocketLog("[chat-socket] room subscribed", { roomId, destination });
   }
 
@@ -1925,7 +1964,21 @@ class ChatStompSession {
 
     this.activeRooms.delete(roomId);
 
+    if (entry.chatHeartbeatTimer !== null) {
+      clearInterval(entry.chatHeartbeatTimer);
+      entry.chatHeartbeatTimer = null;
+    }
+
     if (this.client?.connected && this.config) {
+      const sessionId = this.connectedSessionId;
+      if (sessionId) {
+        this.sendChatParticipantOffline({
+          roomId,
+          participantId: entry.participantId,
+          sessionId,
+        });
+      }
+
       const unsubscribePayload: UnsubscribeRoomRequestPayload = {
         roomId,
         participantId: entry.participantId,


### PR DESCRIPTION
## PR 메타

- Assignees: `happy7yong`
- Milestone: `V2`

## 변경 사항 요약

- 채팅방 room subscribe 직후 `chat.participant.online` 이벤트를 발행하도록 연결했습니다.
- socket handshake 성공 payload에서 `sessionId`를 세션 상태에 저장해 presence payload에 사용하도록 보강했습니다.
- room unsubscribe/teardown 시 `chat.participant.offline` 이벤트를 발행하도록 복구했습니다.
- `sessionId` 미확보 상태에서는 경고 로그를 남기고 안전하게 스킵하도록 처리했습니다.

## 작업 배경/목적

- 채팅방 입장 시 `/pub/room/chat/online` 이벤트가 전송되지 않아 서버 presence 상태가 갱신되지 않는 버그를 수정하기 위함입니다.

## 영향 범위

- `src/shared/socket/chatStompSession.ts`

## 테스트/검증

- `pnpm exec next lint --file src/shared/socket/chatStompSession.ts` 통과
- 코드 경로 검증: room subscribe/unsubscribe 시 online/offline 발행 경로 확인

## 관련 이슈

- Closes #640

## 참고 문서/링크

- 이슈: https://github.com/100-hours-a-week/7-team-temporary-fe/issues/640
